### PR TITLE
Be smarter about which sensors to notify after a poll

### DIFF
--- a/custom_components/foxess_modbus/common/callback_controller.py
+++ b/custom_components/foxess_modbus/common/callback_controller.py
@@ -14,7 +14,7 @@ class CallbackController:
         """Add a listener for update notifications."""
         self._update_listeners.append(listener)
 
-    def _notify_listeners(self) -> None:
+    def _notify_listeners(self, changed_addresses: set[int]) -> None:
         """Notify listeners"""
         for listener in self._update_listeners:
-            listener.update_callback()
+            listener.update_callback(changed_addresses)

--- a/custom_components/foxess_modbus/entities/modbus_entity_mixin.py
+++ b/custom_components/foxess_modbus/entities/modbus_entity_mixin.py
@@ -70,6 +70,7 @@ class ModbusEntityMixin:
         await super().async_added_to_hass()
         self._controller.add_update_listener(self)
 
-    def update_callback(self) -> None:
+    def update_callback(self, changed_addresses: set[int]) -> None:
         """Schedule a state update."""
-        self.schedule_update_ha_state(True)
+        if self.entity_description.address in changed_addresses:
+            self.schedule_update_ha_state(True)

--- a/custom_components/foxess_modbus/entities/modbus_number.py
+++ b/custom_components/foxess_modbus/entities/modbus_number.py
@@ -69,7 +69,6 @@ class ModbusNumber(ModbusEntityMixin, NumberEntity):
         await self._controller.write_register(
             self.entity_description.address, int_value
         )
-        self.update_callback()
 
     @property
     def should_poll(self) -> bool:

--- a/custom_components/foxess_modbus/entities/modbus_select.py
+++ b/custom_components/foxess_modbus/entities/modbus_select.py
@@ -60,7 +60,6 @@ class ModbusSelect(ModbusEntityMixin, SelectEntity):
             return
 
         await self._controller.write_register(self.entity_description.address, value)
-        self.update_callback()
 
     @property
     def should_poll(self) -> bool:


### PR DESCRIPTION
Most of the time, most sensors aren't changing. Telling HA that everything has changed after every poll is a bit wasteful, particularly if the user has the poll rate set high.

Make sure that we only tell HA about registers which have actually changed.