### PR TITLE
Refactor to introduce centralised knowledge of inverter registers and capabilities

### DIFF
--- a/custom_components/foxess_modbus/__init__.py
+++ b/custom_components/foxess_modbus/__init__.py
@@ -8,8 +8,6 @@ import asyncio
 import logging
 
 import voluptuous as vol
-from custom_components.foxess_modbus.const import FRIENDLY_NAME
-from custom_components.foxess_modbus.modbus_client import ModbusClient
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import Config
 from homeassistant.core import HomeAssistant
@@ -17,7 +15,7 @@ from homeassistant.helpers import config_validation as cv
 from pymodbus.exceptions import ModbusIOException
 
 from .const import DOMAIN
-from .const import INVERTER_CONN
+from .const import FRIENDLY_NAME
 from .const import INVERTERS
 from .const import MAX_READ
 from .const import MODBUS_SLAVE
@@ -27,6 +25,8 @@ from .const import POLL_RATE
 from .const import SERIAL
 from .const import STARTUP_MESSAGE
 from .const import TCP
+from .inverter_profiles import inverter_connection_type_profile_from_config
+from .modbus_client import ModbusClient
 from .modbus_controller import ModbusController
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -65,9 +65,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     max_read = entry.data.get(MAX_READ, 8)
 
     def create_controller(hass, client, inverter):
-        conn_type, slave = inverter[INVERTER_CONN], inverter[MODBUS_SLAVE]
         controller = ModbusController(
-            hass, client, conn_type, slave, poll_rate, max_read
+            hass,
+            client,
+            inverter_connection_type_profile_from_config(inverter),
+            inverter[MODBUS_SLAVE],
+            poll_rate,
+            max_read,
         )
         inverter_controller.append((inverter, controller))
 

--- a/custom_components/foxess_modbus/binary_sensor.py
+++ b/custom_components/foxess_modbus/binary_sensor.py
@@ -5,11 +5,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
-from .const import INVERTER_BASE
-from .const import INVERTER_CONN
 from .const import INVERTERS
-from .const import LAN
-from .entities import xx1_aux_binary_sensors
+from .inverter_profiles import inverter_connection_type_profile_from_config
 
 _LOGGER = logging.getLogger(__package__)
 
@@ -22,11 +19,8 @@ async def async_setup_entry(
     inverters = hass.data[DOMAIN][entry.entry_id][INVERTERS]
 
     for inverter, controller in inverters:
-        if inverter[INVERTER_CONN] == LAN:
-            sensors = []
-        else:
-            sensors = xx1_aux_binary_sensors.binary_sensors(
-                inverter[INVERTER_BASE], controller, entry, inverter
-            )
-
-        async_add_devices(sensors)
+        async_add_devices(
+            inverter_connection_type_profile_from_config(
+                inverter
+            ).create_binary_sensors(controller, entry, inverter)
+        )

--- a/custom_components/foxess_modbus/common/entity_controller.py
+++ b/custom_components/foxess_modbus/common/entity_controller.py
@@ -1,10 +1,12 @@
 """Callback controller"""
 import logging
+from abc import ABC
+from abc import abstractmethod
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class CallbackController:
+class EntityController(ABC):
     """Callback controller base"""
 
     def __init__(self) -> None:
@@ -18,3 +20,7 @@ class CallbackController:
         """Notify listeners"""
         for listener in self._update_listeners:
             listener.update_callback(changed_addresses)
+
+    @abstractmethod
+    async def write_register(self, address, value) -> None:
+        """Write a single value to a register"""

--- a/custom_components/foxess_modbus/config_flow.py
+++ b/custom_components/foxess_modbus/config_flow.py
@@ -198,8 +198,7 @@ class ModbusFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             else:
                 params.update({"port": host, "baudrate": 9600})
             client = ModbusClient(self.hass, params)
-            controller = ModbusController(None, client, None, slave, None, None)
-            return (True, await controller.autodetect())
+            return (True, await ModbusController.autodetect(client, slave))
         except ModbusException as ex:
             _LOGGER.warning(f"{ex!r}")
             self._errors["base"] = "modbus_error"

--- a/custom_components/foxess_modbus/const.py
+++ b/custom_components/foxess_modbus/const.py
@@ -39,14 +39,6 @@ INVERTERS = "inverters"
 ADD_ANOTHER = "add_another"
 CONFIG_SAVE_TIME = "save_time"
 
-# Inverter Types
-H1 = "H1"
-AC1 = "AC1"
-AIOH1 = "AIO-H1"
-LAN = "LAN"
-AUTODETECT = [H1, AC1, AIOH1]
-
-AUX = "AUX"
 TCP = "TCP"
 SERIAL = "SERIAL"
 

--- a/custom_components/foxess_modbus/entities/modbus_entity_mixin.py
+++ b/custom_components/foxess_modbus/entities/modbus_entity_mixin.py
@@ -1,14 +1,14 @@
 import logging
 
-from custom_components.foxess_modbus.const import FRIENDLY_NAME
-from custom_components.foxess_modbus.const import INVERTER_CONN
-from custom_components.foxess_modbus.const import INVERTER_MODEL
 from homeassistant.const import ATTR_IDENTIFIERS
 from homeassistant.const import ATTR_MANUFACTURER
 from homeassistant.const import ATTR_MODEL
 from homeassistant.const import ATTR_NAME
 
 from ..const import DOMAIN
+from ..const import FRIENDLY_NAME
+from ..const import INVERTER_CONN
+from ..const import INVERTER_MODEL
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/foxess_modbus/entities/modbus_number.py
+++ b/custom_components/foxess_modbus/entities/modbus_number.py
@@ -8,7 +8,7 @@ from homeassistant.components.number import NumberEntityDescription
 from homeassistant.components.number import NumberMode
 from homeassistant.config_entries import ConfigEntry
 
-from ..modbus_controller import ModbusController
+from ..common.entity_controller import EntityController
 from .modbus_entity_mixin import ModbusEntityMixin
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -29,7 +29,7 @@ class ModbusNumber(ModbusEntityMixin, NumberEntity):
 
     def __init__(
         self,
-        controller: ModbusController,
+        controller: EntityController,
         entity_description: ModbusNumberDescription,
         entry: ConfigEntry,
         inv_details,

--- a/custom_components/foxess_modbus/entities/modbus_select.py
+++ b/custom_components/foxess_modbus/entities/modbus_select.py
@@ -6,7 +6,7 @@ from homeassistant.components.select import SelectEntity
 from homeassistant.components.select import SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
 
-from ..modbus_controller import ModbusController
+from ..common.entity_controller import EntityController
 from .modbus_entity_mixin import ModbusEntityMixin
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -25,7 +25,7 @@ class ModbusSelect(ModbusEntityMixin, SelectEntity):
 
     def __init__(
         self,
-        controller: ModbusController,
+        controller: EntityController,
         entity_description: ModbusSelectDescription,
         entry: ConfigEntry,
         inv_details,

--- a/custom_components/foxess_modbus/entities/modbus_sensor.py
+++ b/custom_components/foxess_modbus/entities/modbus_sensor.py
@@ -8,7 +8,7 @@ from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 
-from ..common.callback_controller import CallbackController
+from ..common.entity_controller import EntityController
 from .modbus_entity_mixin import ModbusEntityMixin
 
 _LOGGER = logging.getLogger(__name__)
@@ -29,7 +29,7 @@ class ModbusSensor(ModbusEntityMixin, SensorEntity):
 
     def __init__(
         self,
-        controller: CallbackController,
+        controller: EntityController,
         entity_description: SensorDescription,
         entry: ConfigEntry,
         inv_details,

--- a/custom_components/foxess_modbus/entities/xx1_aux_binary_sensors.py
+++ b/custom_components/foxess_modbus/entities/xx1_aux_binary_sensors.py
@@ -1,11 +1,6 @@
 """Inverter sensor"""
 import logging
 
-from custom_components.foxess_modbus.const import AC1
-from custom_components.foxess_modbus.const import AIOH1
-from custom_components.foxess_modbus.const import H1
-
-from .modbus_sensor import ModbusSensor
 from .modbus_sensor import SensorDescription
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -24,15 +19,3 @@ SENSORS: list[SensorDescription] = [
         post_process=lambda v: "On" if v else "Off",
     ),
 ]
-
-
-COMPAT: dict[str, list] = {H1: SENSORS, AIOH1: SENSORS, AC1: SENSORS}
-
-
-def binary_sensors(base_model, controller, entry, inverter) -> list:
-    """Setup binary sensor platform."""
-
-    return list(
-        ModbusSensor(controller, number, entry, inverter)
-        for number in COMPAT[base_model]
-    )

--- a/custom_components/foxess_modbus/entities/xx1_aux_numbers.py
+++ b/custom_components/foxess_modbus/entities/xx1_aux_numbers.py
@@ -1,13 +1,9 @@
 """Inverter sensor"""
 import logging
 
-from custom_components.foxess_modbus.const import AC1
-from custom_components.foxess_modbus.const import AIOH1
-from custom_components.foxess_modbus.const import H1
 from homeassistant.components.number import NumberDeviceClass
 from homeassistant.components.number import NumberMode
 
-from .modbus_number import ModbusNumber
 from .modbus_number import ModbusNumberDescription
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -50,14 +46,3 @@ NUMBERS: list[ModbusNumberDescription] = [
         icon="mdi:battery-arrow-up",
     ),
 ]
-
-COMPAT: dict[str, list] = {H1: NUMBERS, AIOH1: NUMBERS, AC1: NUMBERS}
-
-
-def numbers(base_model, controller, entry, inverter) -> list:
-    """Setup number platform."""
-
-    return list(
-        ModbusNumber(controller, number, entry, inverter)
-        for number in COMPAT[base_model]
-    )

--- a/custom_components/foxess_modbus/entities/xx1_aux_selects.py
+++ b/custom_components/foxess_modbus/entities/xx1_aux_selects.py
@@ -1,15 +1,9 @@
 """Inverter Select entities"""
 import logging
 
-from custom_components.foxess_modbus.const import AC1
-from custom_components.foxess_modbus.const import AIOH1
-from custom_components.foxess_modbus.const import H1
-
-from .modbus_select import ModbusSelect
 from .modbus_select import ModbusSelectDescription
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
-
 
 SELECTS: list[ModbusSelectDescription] = [
     ModbusSelectDescription(
@@ -19,14 +13,3 @@ SELECTS: list[ModbusSelectDescription] = [
         options_map={0: "Self Use", 1: "Feed-in First", 2: "Back-up"},
     ),
 ]
-
-COMPAT: dict[str, list] = {H1: SELECTS, AIOH1: SELECTS, AC1: SELECTS}
-
-
-def selects(base_model, controller, entry, inverter) -> list:
-    """Setup select platform."""
-
-    return list(
-        ModbusSelect(controller, select, entry, inverter)
-        for select in COMPAT[base_model]
-    )

--- a/custom_components/foxess_modbus/entities/xx1_aux_sensors.py
+++ b/custom_components/foxess_modbus/entities/xx1_aux_sensors.py
@@ -5,10 +5,6 @@ from datetime import time
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.components.sensor import SensorStateClass
 
-from ..const import AC1
-from ..const import AIOH1
-from ..const import H1
-from .modbus_sensor import ModbusSensor
 from .modbus_sensor import SensorDescription
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -370,17 +366,3 @@ H1_AC1_SENSORS: list[SensorDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
     ),
 ]
-
-COMPAT: dict[str, list] = {
-    H1: H1_SENSORS + H1_AC1_SENSORS,
-    AIOH1: H1_SENSORS + H1_AC1_SENSORS,
-    AC1: H1_AC1_SENSORS,
-}
-
-
-def sensors(base_model, controller, entry, inverter) -> list:
-    """Return compatible sensors"""
-    return list(
-        ModbusSensor(controller, sensor, entry, inverter)
-        for sensor in COMPAT[base_model]
-    )

--- a/custom_components/foxess_modbus/entities/xx1_lan_sensors.py
+++ b/custom_components/foxess_modbus/entities/xx1_lan_sensors.py
@@ -1,13 +1,9 @@
 """Inverter sensor"""
 import logging
 
-from custom_components.foxess_modbus.const import AC1
-from custom_components.foxess_modbus.const import AIOH1
-from custom_components.foxess_modbus.const import H1
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.components.sensor import SensorStateClass
 
-from .modbus_sensor import ModbusSensor
 from .modbus_sensor import SensorDescription
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -209,17 +205,3 @@ H1_AC1_SENSORS: list[SensorDescription] = [
         scale=0.1,
     ),
 ]
-
-COMPAT: dict[str, list] = {
-    H1: H1_SENSORS + H1_AC1_SENSORS,
-    AIOH1: H1_SENSORS + H1_AC1_SENSORS,
-    AC1: H1_AC1_SENSORS,
-}
-
-
-def sensors(base_model, controller, entry, inverter) -> list:
-    """Return compatible sensors"""
-    return list(
-        ModbusSensor(controller, sensor, entry, inverter)
-        for sensor in COMPAT[base_model]
-    )

--- a/custom_components/foxess_modbus/inverter_connection_types.py
+++ b/custom_components/foxess_modbus/inverter_connection_types.py
@@ -1,0 +1,28 @@
+"""Contains knowledge of the various ways to connect to inverters"""
+import logging
+
+_LOGGER = logging.getLogger(__package__)
+
+
+class InverterConnectionType:
+    """Describes a means of connecting to an inverter"""
+
+    def __init__(
+        self, key: str, read_holding_registers: bool, serial_start_address: int
+    ) -> None:
+        self.key = key
+        self.read_holding_registers = read_holding_registers
+        self.serial_start_address = serial_start_address
+
+
+CONNECTION_TYPES = {
+    x.key: x
+    for x in [
+        InverterConnectionType(
+            key="AUX", read_holding_registers=False, serial_start_address=10000
+        ),
+        InverterConnectionType(
+            key="LAN", read_holding_registers=True, serial_start_address=30000
+        ),
+    ]
+}

--- a/custom_components/foxess_modbus/inverter_profiles.py
+++ b/custom_components/foxess_modbus/inverter_profiles.py
@@ -1,0 +1,208 @@
+"""Defines the different inverter models and connection types"""
+import logging
+from typing import Any
+from typing import Iterable
+
+from homeassistant.config_entries import ConfigEntry
+
+from .common.entity_controller import EntityController
+from .const import INVERTER_BASE
+from .const import INVERTER_CONN
+from .entities import xx1_aux_binary_sensors
+from .entities import xx1_aux_numbers
+from .entities import xx1_aux_selects
+from .entities import xx1_aux_sensors
+from .entities import xx1_lan_sensors
+from .entities.modbus_number import ModbusNumber
+from .entities.modbus_number import ModbusNumberDescription
+from .entities.modbus_select import ModbusSelect
+from .entities.modbus_select import ModbusSelectDescription
+from .entities.modbus_sensor import ModbusSensor
+from .entities.modbus_sensor import SensorDescription
+from .inverter_connection_types import CONNECTION_TYPES
+from .inverter_connection_types import InverterConnectionType
+
+_LOGGER = logging.getLogger(__package__)
+
+
+class InverterModelConnectionTypeProfile:
+    """Describes the capabilities of an inverter when connected to over a particular interface"""
+
+    def __init__(
+        self,
+        connection_type: InverterConnectionType,
+        sensors: list[SensorDescription],
+        binary_sensors: list[SensorDescription],
+        numbers: list[ModbusNumberDescription],
+        selects: list[ModbusSelectDescription],
+        address_ranges: list[tuple[int, int]],
+    ) -> None:
+        self.connection_type = connection_type
+        self.sensors = sensors
+        self.binary_sensors = binary_sensors
+        self.numbers = numbers
+        self.selects = selects
+
+        self._address_ranges = address_ranges
+
+    def create_read_ranges(self, max_read: int) -> Iterable[tuple[int, int]]:
+        """
+        Generates a set of read ranges to cover the addresses of all registers on this inverter,
+        respecting the maxumum number of registers to read at a time
+
+        :returns: Sequence of tuples of (start_address, num_registers_to_read)
+        """
+
+        # TODO: I want to make this a lot smarter. We know the addresses of all sensors, so we can use this to
+        # generate an optimal sequence of reads
+        for start, end in self._address_ranges:
+            for i in range(start, end, max_read):
+                data_per_read = min(max_read, end - i)
+                yield (i, data_per_read)
+
+    def create_sensors(
+        self,
+        controller: EntityController,
+        entry: ConfigEntry,
+        inverter_details: dict[str, Any],
+    ) -> list[ModbusSensor]:
+        """Instantiates all sensors for this connection type"""
+        return list(
+            ModbusSensor(controller, sensor, entry, inverter_details)
+            for sensor in self.sensors
+        )
+
+    def create_binary_sensors(
+        self,
+        controller: EntityController,
+        entry: ConfigEntry,
+        inverter_details: dict[str, Any],
+    ) -> list[ModbusSensor]:
+        """Instantiates all binary sensors for this connection type"""
+        return list(
+            ModbusSensor(controller, sensor, entry, inverter_details)
+            for sensor in self.binary_sensors
+        )
+
+    def create_numbers(
+        self,
+        controller: EntityController,
+        entry: ConfigEntry,
+        inverter_details: dict[str, Any],
+    ) -> list[ModbusSensor]:
+        """Instantiates all number entities for this connection type"""
+        return list(
+            ModbusNumber(controller, sensor, entry, inverter_details)
+            for sensor in self.numbers
+        )
+
+    def create_selects(
+        self,
+        controller: EntityController,
+        entry: ConfigEntry,
+        inverter_details: dict[str, Any],
+    ) -> list[ModbusSensor]:
+        """Instantiates all number entities for this connection type"""
+        return list(
+            ModbusSelect(controller, sensor, entry, inverter_details)
+            for sensor in self.selects
+        )
+
+
+class InverterModelProfile:
+    """Describes the capabilities of an inverter model"""
+
+    def __init__(
+        self, model: str, connection_types: list[InverterModelConnectionTypeProfile]
+    ) -> None:
+        self.model = model
+        self.connection_types = {x.connection_type.key: x for x in connection_types}
+
+
+INVERTER_PROFILES = {
+    x.model: x
+    for x in [
+        InverterModelProfile(
+            model="H1",
+            connection_types=[
+                InverterModelConnectionTypeProfile(
+                    connection_type=CONNECTION_TYPES["AUX"],
+                    sensors=xx1_aux_sensors.H1_SENSORS + xx1_aux_sensors.H1_AC1_SENSORS,
+                    binary_sensors=xx1_aux_binary_sensors.SENSORS,
+                    numbers=xx1_aux_numbers.NUMBERS,
+                    selects=xx1_aux_selects.SELECTS,
+                    address_ranges=[
+                        (11000, 11050),
+                        (41000, 41012),
+                    ],
+                ),
+                InverterModelConnectionTypeProfile(
+                    connection_type=CONNECTION_TYPES["LAN"],
+                    sensors=xx1_lan_sensors.H1_SENSORS + xx1_lan_sensors.H1_AC1_SENSORS,
+                    binary_sensors=[],
+                    numbers=[],
+                    selects=[],
+                    address_ranges=[(31000, 31025)],
+                ),
+            ],
+        ),
+        InverterModelProfile(
+            model="AC1",
+            connection_types=[
+                InverterModelConnectionTypeProfile(
+                    connection_type=CONNECTION_TYPES["AUX"],
+                    sensors=xx1_aux_sensors.H1_AC1_SENSORS,
+                    binary_sensors=xx1_aux_binary_sensors.SENSORS,
+                    numbers=xx1_aux_numbers.NUMBERS,
+                    selects=xx1_aux_selects.SELECTS,
+                    address_ranges=[
+                        (11000, 11050),
+                        (41000, 41012),
+                    ],
+                ),
+                InverterModelConnectionTypeProfile(
+                    connection_type=CONNECTION_TYPES["LAN"],
+                    sensors=xx1_lan_sensors.H1_AC1_SENSORS,
+                    binary_sensors=[],
+                    numbers=[],
+                    selects=[],
+                    address_ranges=[(31000, 31025)],
+                ),
+            ],
+        ),
+        InverterModelProfile(
+            model="AIO-H1",
+            connection_types=[
+                InverterModelConnectionTypeProfile(
+                    connection_type=CONNECTION_TYPES["AUX"],
+                    sensors=xx1_aux_sensors.H1_SENSORS + xx1_aux_sensors.H1_AC1_SENSORS,
+                    binary_sensors=xx1_aux_binary_sensors.SENSORS,
+                    numbers=xx1_aux_numbers.NUMBERS,
+                    selects=xx1_aux_selects.SELECTS,
+                    address_ranges=[
+                        (11000, 11050),
+                        (41000, 41012),
+                    ],
+                ),
+                InverterModelConnectionTypeProfile(
+                    connection_type=CONNECTION_TYPES["LAN"],
+                    sensors=xx1_lan_sensors.H1_SENSORS + xx1_lan_sensors.H1_AC1_SENSORS,
+                    binary_sensors=[],
+                    numbers=[],
+                    selects=[],
+                    address_ranges=[(31000, 31025)],
+                ),
+            ],
+        ),
+    ]
+}
+
+
+def inverter_connection_type_profile_from_config(
+    inverter_config: dict[str, Any]
+) -> InverterModelConnectionTypeProfile:
+    """Fetches a InverterConnectionTypeProfile for a given configuration object"""
+
+    return INVERTER_PROFILES[inverter_config[INVERTER_BASE]].connection_types[
+        inverter_config[INVERTER_CONN]
+    ]

--- a/custom_components/foxess_modbus/modbus_client.py
+++ b/custom_components/foxess_modbus/modbus_client.py
@@ -2,12 +2,13 @@ import asyncio
 import logging
 from typing import Any
 
-from custom_components.foxess_modbus.const import MODBUS_TYPE
-from custom_components.foxess_modbus.const import SERIAL
-from custom_components.foxess_modbus.const import TCP
 from pymodbus.client import ModbusSerialClient
 from pymodbus.client import ModbusTcpClient
 from pymodbus.exceptions import ModbusIOException
+
+from .const import MODBUS_TYPE
+from .const import SERIAL
+from .const import TCP
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/foxess_modbus/modbus_controller.py
+++ b/custom_components/foxess_modbus/modbus_controller.py
@@ -4,50 +4,43 @@ import queue
 from asyncio.exceptions import TimeoutError
 from datetime import timedelta
 
-from custom_components.foxess_modbus.const import AUTODETECT
-from custom_components.foxess_modbus.const import AUX
-from custom_components.foxess_modbus.const import LAN
 from homeassistant.helpers.event import async_track_time_interval
 from pymodbus.exceptions import ModbusException
 
-from .common.callback_controller import CallbackController
+from .common.entity_controller import EntityController
 from .common.unload_controller import UnloadController
+from .inverter_profiles import CONNECTION_TYPES
+from .inverter_profiles import INVERTER_PROFILES
+from .inverter_profiles import InverterModelConnectionTypeProfile
+from .modbus_client import ModbusClient
 
 _LOGGER = logging.getLogger(__name__)
 
-_SERIALS = {AUX: 10000, LAN: 30000}
-# LAN uses holding registers / AUX uses input registers
-_HOLDING = {AUX: False, LAN: True}
 
-_ADDRESSES = {
-    LAN: [
-        (31000, 31025),
-    ],
-    AUX: [
-        (11000, 11050),
-        (41000, 41012),
-    ],
-}
-
-
-class ModbusController(CallbackController, UnloadController):
+class ModbusController(EntityController, UnloadController):
     """Class to manage forecast retrieval"""
 
     def __init__(
-        self, hass, client, connection_type, slave, poll_rate, max_read
+        self,
+        hass,
+        client: ModbusClient,
+        connection_type_profile: InverterModelConnectionTypeProfile,
+        slave: int,
+        poll_rate: int,
+        max_read: int,
     ) -> None:
         """Init"""
         self._hass = hass
         self._data = dict()
         self._client = client
-        self._connection_type = connection_type
+        self._connection_type_profile = connection_type_profile
         self._slave = slave
         self._poll_rate = poll_rate
         self._max_read = max_read
         self._write_queue = queue.Queue()
 
         # Setup mixins
-        CallbackController.__init__(self)
+        EntityController.__init__(self)
         UnloadController.__init__(self)
 
         if self._hass is not None:
@@ -90,21 +83,24 @@ class ModbusController(CallbackController, UnloadController):
 
     async def refresh(self, *args) -> None:
         """Refresh modbus data"""
-        holding = _HOLDING[self._connection_type]
+        holding = self._connection_type_profile.connection_type.read_holding_registers
         try:
             changed_addresses = set()
-            for start, end in _ADDRESSES[self._connection_type]:
-                _LOGGER.debug(f"Reading addresses for ({start}:{end-start})")
-                for i in range(start, end, self._max_read):
-                    data_per_read = min(self._max_read, end - i)
-                    data = await self._client.read_registers(
-                        i, data_per_read, holding, self._slave
-                    )
-                    for j, d in enumerate(data):
-                        address = i + j
-                        if self._data.get(address) != d:
-                            changed_addresses.add(address)
-                            self._data[address] = d
+            for (
+                start_address,
+                num_reads,
+            ) in self._connection_type_profile.create_read_ranges(self._max_read):
+                _LOGGER.debug(
+                    "Reading addresses for (%s, %s)", start_address, num_reads
+                )
+                reads = await self._client.read_registers(
+                    start_address, num_reads, holding, self._slave
+                )
+                for i, value in enumerate(reads):
+                    address = start_address + i
+                    if self._data.get(address) != value:
+                        changed_addresses.add(address)
+                        self._data[address] = value
 
             _LOGGER.debug("Refresh complete - notifying sensors: %s", changed_addresses)
             self._notify_listeners(changed_addresses)
@@ -115,24 +111,34 @@ class ModbusController(CallbackController, UnloadController):
         except Exception as ex:
             _LOGGER.debug(f"General exception when polling - {ex!r}")
 
-    async def autodetect(self) -> bool:
-        """Modbus status"""
-        for conn_type, serial_addr in _SERIALS.items():
-            holding = _HOLDING[conn_type]
+    @staticmethod
+    async def autodetect(client: ModbusClient, slave: int) -> tuple[str, str, str]:
+        """
+        Attempts to auto-detect the inverter type at the other end of the given connection
+
+        :returns: Tuple of (inverter type name e.g. "H1", inverter full name e.g. "H1-3.7", connection type e.g. "LAN")
+        """
+        for conn_type_name, conn_type in CONNECTION_TYPES.items():
             try:
-                result = await self._client.read_registers(
-                    serial_addr, 10, holding, self._slave
+                result = await client.read_registers(
+                    conn_type.serial_start_address,
+                    10,
+                    conn_type.read_holding_registers,
+                    slave,
                 )
-                for model in AUTODETECT:
-                    inverter_str = "".join([chr(i) for i in result])
-                    base_model = inverter_str[: len(model)]
-                    if base_model == model:
-                        full_model = inverter_str[: len(model) + 4]
-                        _LOGGER.info(
-                            f"Autodetected inverter as {full_model} using {conn_type} connection"
-                        )
-                        return base_model, full_model, conn_type
+                for model_key, model in INVERTER_PROFILES.items():
+                    if conn_type_name in model.connection_types:
+                        inverter_str = "".join([chr(i) for i in result])
+                        base_model = inverter_str[: len(model.model)]
+                        if base_model == model.model:
+                            full_model = inverter_str[: len(model.model) + 4]
+                            _LOGGER.info(
+                                "Autodetected inverter as %s using %s connection",
+                                full_model,
+                                conn_type_name,
+                            )
+                            return model_key, full_model, conn_type_name
 
                 raise ConnectionRefusedError(f"{inverter_str} not supported")
             finally:
-                await self._client.close()
+                await client.close()

--- a/custom_components/foxess_modbus/number.py
+++ b/custom_components/foxess_modbus/number.py
@@ -5,11 +5,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
-from .const import INVERTER_BASE
-from .const import INVERTER_CONN
 from .const import INVERTERS
-from .const import LAN
-from .entities import xx1_aux_numbers
+from .inverter_profiles import inverter_connection_type_profile_from_config
 
 _LOGGER = logging.getLogger(__package__)
 
@@ -22,11 +19,8 @@ async def async_setup_entry(
     inverters = hass.data[DOMAIN][entry.entry_id][INVERTERS]
 
     for inverter, controller in inverters:
-        if inverter[INVERTER_CONN] == LAN:
-            numbers = []
-        else:
-            numbers = xx1_aux_numbers.numbers(
-                inverter[INVERTER_BASE], controller, entry, inverter
+        async_add_devices(
+            inverter_connection_type_profile_from_config(inverter).create_numbers(
+                controller, entry, inverter
             )
-
-        async_add_devices(numbers)
+        )

--- a/custom_components/foxess_modbus/select.py
+++ b/custom_components/foxess_modbus/select.py
@@ -5,11 +5,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
-from .const import INVERTER_BASE
-from .const import INVERTER_CONN
 from .const import INVERTERS
-from .const import LAN
-from .entities import xx1_aux_selects
+from .inverter_profiles import inverter_connection_type_profile_from_config
 
 _LOGGER = logging.getLogger(__package__)
 
@@ -22,11 +19,8 @@ async def async_setup_entry(
     inverters = hass.data[DOMAIN][entry.entry_id][INVERTERS]
 
     for inverter, controller in inverters:
-        if inverter[INVERTER_CONN] == LAN:
-            selects = []
-        else:
-            selects = xx1_aux_selects.selects(
-                inverter[INVERTER_BASE], controller, entry, inverter
+        async_add_devices(
+            inverter_connection_type_profile_from_config(inverter).create_selects(
+                controller, entry, inverter
             )
-
-        async_add_devices(selects)
+        )

--- a/custom_components/foxess_modbus/sensor.py
+++ b/custom_components/foxess_modbus/sensor.py
@@ -5,12 +5,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
-from .const import INVERTER_BASE
-from .const import INVERTER_CONN
 from .const import INVERTERS
-from .const import LAN
-from .entities import xx1_aux_sensors
-from .entities import xx1_lan_sensors
+from .inverter_profiles import inverter_connection_type_profile_from_config
 
 _LOGGER = logging.getLogger(__package__)
 
@@ -23,13 +19,8 @@ async def async_setup_entry(
     inverters = hass.data[DOMAIN][entry.entry_id][INVERTERS]
 
     for inverter, controller in inverters:
-        if inverter[INVERTER_CONN] == LAN:
-            sensors = xx1_lan_sensors.sensors(
-                inverter[INVERTER_BASE], controller, entry, inverter
+        async_add_devices(
+            inverter_connection_type_profile_from_config(inverter).create_sensors(
+                controller, entry, inverter
             )
-        else:
-            sensors = xx1_aux_sensors.sensors(
-                inverter[INVERTER_BASE], controller, entry, inverter
-            )
-
-        async_add_devices(sensors)
+        )


### PR DESCRIPTION
This is quite a big change, sorry! I didn't quite know where it was going to end up when I started, and I quite understand if you don't want to take it. Also very happy to take a review and make changes.

The motivation is twofold:

1. Generating an optimal sequence of register reads for a particular interver. This means knowing all of the address of all registers on a particular inverter
2. Writing force charge windows is probably going to need some centralised knowledge about an inverter (such as which registers need to be written in one block), and currently the knowledge about an inverter is spread across the codebase

The central points are inverter_connection_types, a list of ways to connect to inverters, and and inverter_profiles, a list of all inverter models which are supported, along with inverter-model-specific metadata, and the list of entities which are supported by that inverter model.

All parts of the codebase which need to deal with the differences between inverter models and connection types now go through these central points.

The `address_ranges` members will go when I get the address read grouping in place. I'll only bother with that if you want to accept this however (or something else, which means that we have single list of all addresses for a particular inverter)