### PR TITLE
Be smarter about grouping address into read commands

### DIFF
--- a/custom_components/foxess_modbus/modbus_client.py
+++ b/custom_components/foxess_modbus/modbus_client.py
@@ -35,13 +35,14 @@ class ModbusClient:
         """Connect to device"""
 
         def connect_impl():
-            self._client.connect()
+            result = self._client.connect()
             # pymodbus doesn't disable Nagle's algorithm. This slows down reads quite substantially as the
             # TCP stack waits to see if we're going to send anything else. Disable it ourselves.
             if isinstance(self._client, ModbusTcpClient):
                 self._client.socket.setsockopt(
                     socket.IPPROTO_TCP, socket.TCP_NODELAY, True
                 )
+            return result
 
         _LOGGER.debug(f"Connecting to modbus - ({self._config})")
         if not await self._async_pymodbus_call(connect_impl):

--- a/custom_components/foxess_modbus/modbus_controller.py
+++ b/custom_components/foxess_modbus/modbus_controller.py
@@ -31,7 +31,7 @@ class ModbusController(EntityController, UnloadController):
     ) -> None:
         """Init"""
         self._hass = hass
-        self._data = dict()
+        self._data = {x: None for x in connection_type_profile.all_addresses}
         self._client = client
         self._connection_type_profile = connection_type_profile
         self._slave = slave
@@ -54,10 +54,7 @@ class ModbusController(EntityController, UnloadController):
 
     def read(self, address) -> bool:
         """Modbus status"""
-        if address in self._data:
-            return self._data[address]
-        else:
-            return None
+        return self._data.get(address)
 
     async def write(self, service) -> bool:
         """Modbus write"""
@@ -76,6 +73,7 @@ class ModbusController(EntityController, UnloadController):
         changed_addresses = set()
         for i, value in enumerate(values):
             address = start_address + i
+            # Only store the result of the write if it's a register we care about ourselves
             if self._data.get(address, value) != value:
                 self._data[address] = value
                 changed_addresses.add(address)
@@ -98,7 +96,8 @@ class ModbusController(EntityController, UnloadController):
                 )
                 for i, value in enumerate(reads):
                     address = start_address + i
-                    if self._data.get(address) != value:
+                    # We might be reading a register we don't care about (for efficiency). Discard it if so
+                    if self._data.get(address, value) != value:
                         changed_addresses.add(address)
                         self._data[address] = value
 


### PR DESCRIPTION
For a H1 AUX with a read size of 8, this reduces the number of reads from 9 to 7, although it's not optimal in the general case.
    
It also avoids having to hard-code the address range for each inverter model.
