### PR TITLE
Better handle multiple addresses

### DIFF
--- a/custom_components/foxess_modbus/entities/modbus_charge_period_sensors.py
+++ b/custom_components/foxess_modbus/entities/modbus_charge_period_sensors.py
@@ -194,9 +194,17 @@ class ModbusEnableForceChargeSensor(ModbusEntityMixin, BinarySensorEntity):
 
         if (
             start_time is None
-            or not self._validate(rules, start_time)
+            or not self._validate(
+                rules,
+                start_time,
+                address_override=self.entity_description.period_start_address,
+            )
             or end_time is None
-            or not self._validate(rules, end_time)
+            or not self._validate(
+                rules,
+                end_time,
+                address_override=self.entity_description.period_end_address,
+            )
         ):
             return None
 

--- a/custom_components/foxess_modbus/entities/modbus_entity_mixin.py
+++ b/custom_components/foxess_modbus/entities/modbus_entity_mixin.py
@@ -80,18 +80,31 @@ class ModbusEntityMixin:
         else:
             return f"{self.entity_description.key}"
 
-    def _validate(self, rules: list[BaseValidator], processed, original=None) -> bool:
+    def _validate(
+        self,
+        rules: list[BaseValidator],
+        processed,
+        original=None,
+        address_override: int | None = None,
+    ) -> bool:
         """Validate against a set of rules"""
         original = original if original is not None else processed
 
         valid = True
         for rule in rules:
             if not rule.validate(processed):
+                if address_override is not None:
+                    address = address_override
+                elif hasattr(self.entity_description, "address"):
+                    address = self.entity_description.address
+                else:
+                    address = None
                 _LOGGER.warning(
-                    "Value (%s: %s) for address (%s) failed validation against rule (%s : %s)",
+                    "Value (%s: %s) for entity '%s' address '%s' failed validation against rule (%s : %s)",
                     original,
                     processed,
-                    self.entity_description.address,
+                    self.entity_id,
+                    address,
                     type(rule).__name__,
                     vars(rule),
                 )

--- a/custom_components/foxess_modbus/entities/modbus_entity_mixin.py
+++ b/custom_components/foxess_modbus/entities/modbus_entity_mixin.py
@@ -22,7 +22,7 @@ class ModbusEntityMixin:
     It assumes that the following propties are defined on the class:
 
         controller: CallbackController
-        entity_description: EntityDescription
+        entity_description: EntityDescription, EntityFactory
         _inv_details
     """
 
@@ -65,8 +65,12 @@ class ModbusEntityMixin:
 
     def update_callback(self, changed_addresses: set[int]) -> None:
         """Schedule a state update."""
-        if self.entity_description.address in changed_addresses:
-            self.schedule_update_ha_state(True)
+        if any(x in changed_addresses for x in self.entity_description.addresses):
+            self._address_updated()
+
+    def _address_updated(self) -> None:
+        """Called when the controller reads an updated to any of the addresses in entity_description.addresses"""
+        self.schedule_update_ha_state(True)
 
     def _get_unique_id(self):
         """Get unique ID"""

--- a/custom_components/foxess_modbus/entities/modbus_integration_sensor.py
+++ b/custom_components/foxess_modbus/entities/modbus_integration_sensor.py
@@ -24,8 +24,6 @@ _LOGGER = logging.getLogger(__name__)
 class ModbusIntegrationSensorDescription(SensorEntityDescription, EntityFactory):
     """Custom sensor description"""
 
-    # Unused for this sensor type
-    address = 0
     integration_method: str
     name: str
     round_digits: int


### PR DESCRIPTION
Teach ModbusEntityMixin to handle entities with multiple addresses. We now read the addresses property off the EntityFactory, rather than assuming that the entity_description has a single address, when responding to update_callback.

_validate: Don't assume that the entity has a single address. Always log the entity_id, and allow the caller to specify an address to log.