### PR TITLE
Make sure that we only write ints to registers, not strs

### DIFF
--- a/custom_components/foxess_modbus/modbus_controller.py
+++ b/custom_components/foxess_modbus/modbus_controller.py
@@ -75,6 +75,7 @@ class ModbusController(EntityController, UnloadController):
         changed_addresses = set()
         for i, value in enumerate(values):
             address = start_address + i
+            value = int(value)  # Ensure that we've been given an int
             # Only store the result of the write if it's a register we care about ourselves
             if self._data.get(address, value) != value:
                 self._data[address] = value


### PR DESCRIPTION
Otherwise self._data ends up with a str in it, with confuses sensors.

Fixes: #105