### PR TITLE
Part 2 of properly supporting charge windows

### DIFF
--- a/custom_components/foxess_modbus/__init__.py
+++ b/custom_components/foxess_modbus/__init__.py
@@ -98,6 +98,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         _WRITE_SCHEMA,
     )
 
+    hass.services.async_register(
+        DOMAIN,
+        "update_charge_period",
+        lambda data: None,
+        _WRITE_SCHEMA,
+    )
+
     hass.data[DOMAIN][entry.entry_id] = {
         INVERTERS: inverter_controller,
     }

--- a/custom_components/foxess_modbus/__init__.py
+++ b/custom_components/foxess_modbus/__init__.py
@@ -7,15 +7,11 @@ https://github.com/nathanmarlor/foxess_modbus
 import asyncio
 import logging
 
-import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import Config
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv
-from pymodbus.exceptions import ModbusIOException
 
 from .const import DOMAIN
-from .const import FRIENDLY_NAME
 from .const import INVERTERS
 from .const import MAX_READ
 from .const import MODBUS_SLAVE
@@ -28,16 +24,10 @@ from .const import TCP
 from .inverter_profiles import inverter_connection_type_profile_from_config
 from .modbus_client import ModbusClient
 from .modbus_controller import ModbusController
+from .services import update_charge_period_service
+from .services import write_registers_service
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
-
-_WRITE_SCHEMA = vol.Schema(
-    {
-        vol.Optional("friendly_name", description="Friendly Name"): cv.string,
-        vol.Required("start_address", description="Start Address"): int,
-        vol.Required("values", description="Values"): cv.string,
-    }
-)
 
 
 async def async_setup(hass: HomeAssistant, config: Config):
@@ -89,21 +79,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             for _, inverter in name_dict.items():
                 create_controller(hass, client, inverter)
 
-    hass.services.async_register(
-        DOMAIN,
-        "write_registers",
-        lambda data: asyncio.run_coroutine_threadsafe(
-            write_service(inverter_controller, data), hass.loop
-        ),
-        _WRITE_SCHEMA,
-    )
-
-    hass.services.async_register(
-        DOMAIN,
-        "update_charge_period",
-        lambda data: None,
-        _WRITE_SCHEMA,
-    )
+    write_registers_service.register(hass, inverter_controller)
+    update_charge_period_service.register(hass, inverter_controller)
 
     hass.data[DOMAIN][entry.entry_id] = {
         INVERTERS: inverter_controller,
@@ -114,18 +91,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     )
 
     return True
-
-
-async def write_service(*args):
-    """Write service"""
-    try:
-        mapping, service_data = args[0], args[1]
-        friendly_name = service_data.data.get(FRIENDLY_NAME, "")
-        for inverter, controller in mapping:
-            if inverter[FRIENDLY_NAME] == friendly_name:
-                await controller.write(service_data)
-    except ModbusIOException as ex:
-        _LOGGER.warning(ex, exc_info=1)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/foxess_modbus/common/entity_controller.py
+++ b/custom_components/foxess_modbus/common/entity_controller.py
@@ -26,5 +26,5 @@ class EntityController(ABC):
         """Write a single value to a register"""
 
     @abstractmethod
-    async def read(self, address: int) -> int | None:
+    def read(self, address: int) -> int | None:
         """Fetch the last-read value for the given address, or None if none is avaiable"""

--- a/custom_components/foxess_modbus/entities/base_validator.py
+++ b/custom_components/foxess_modbus/entities/base_validator.py
@@ -1,0 +1,11 @@
+"""Validation"""
+from abc import ABC
+from abc import abstractmethod
+
+
+class BaseValidator(ABC):
+    """Base validator"""
+
+    @abstractmethod
+    def validate(self, data) -> bool:
+        """Validate a value against a set of rules"""

--- a/custom_components/foxess_modbus/entities/modbus_binary_sensor.py
+++ b/custom_components/foxess_modbus/entities/modbus_binary_sensor.py
@@ -3,7 +3,6 @@ import logging
 from dataclasses import dataclass
 from dataclasses import field
 
-from custom_components.foxess_modbus.entities.validation import BaseValidator
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.components.binary_sensor import BinarySensorEntityDescription
 from homeassistant.components.sensor import SensorStateClass
@@ -11,6 +10,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity import Entity
 
 from ..common.entity_controller import EntityController
+from .base_validator import BaseValidator
 from .entity_factory import EntityFactory
 from .modbus_entity_mixin import ModbusEntityMixin
 

--- a/custom_components/foxess_modbus/entities/modbus_charge_period_config.py
+++ b/custom_components/foxess_modbus/entities/modbus_charge_period_config.py
@@ -28,6 +28,10 @@ class ModbusChargePeriodConfig:
         enable_charge_from_grid_name: str,
         enable_charge_from_grid_address: int,
     ) -> None:
+        self.period_start_address = period_start_address
+        self.period_end_address = period_end_address
+        self.enable_charge_from_grid_address = enable_charge_from_grid_address
+
         self.period_start = ModbusChargePeriodStartEndSensorDescription(
             key=period_start_key,
             name=period_start_name,

--- a/custom_components/foxess_modbus/entities/modbus_charge_period_config.py
+++ b/custom_components/foxess_modbus/entities/modbus_charge_period_config.py
@@ -53,6 +53,8 @@ class ModbusChargePeriodConfig:
             key=enable_charge_from_grid_key,
             name=enable_charge_from_grid_name,
             address=enable_charge_from_grid_address,
+            # The 'Update Charge Period' service only accepts devices with this device_class,
+            # so ensure that only inverters which support this provide a sensor with this device_class
             device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
         )
 

--- a/custom_components/foxess_modbus/entities/modbus_entity_mixin.py
+++ b/custom_components/foxess_modbus/entities/modbus_entity_mixin.py
@@ -43,6 +43,7 @@ class ModbusEntityMixin:
             attr_name = "FoxESS - Modbus"
 
         return {
+            # services/utils.py relies on the order of entries here. Update that if you update this!
             ATTR_IDENTIFIERS: {(DOMAIN, inv_model, conn_type, friendly_name)},
             ATTR_NAME: attr_name,
             ATTR_MODEL: f"{inv_model} - {conn_type}",

--- a/custom_components/foxess_modbus/entities/modbus_entity_mixin.py
+++ b/custom_components/foxess_modbus/entities/modbus_entity_mixin.py
@@ -1,6 +1,5 @@
 import logging
 
-from custom_components.foxess_modbus.entities.validation import BaseValidator
 from homeassistant.const import ATTR_IDENTIFIERS
 from homeassistant.const import ATTR_MANUFACTURER
 from homeassistant.const import ATTR_MODEL
@@ -10,6 +9,7 @@ from ..const import DOMAIN
 from ..const import FRIENDLY_NAME
 from ..const import INVERTER_CONN
 from ..const import INVERTER_MODEL
+from .base_validator import BaseValidator
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/foxess_modbus/entities/modbus_number.py
+++ b/custom_components/foxess_modbus/entities/modbus_number.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from dataclasses import field
 from typing import Callable
 
-from custom_components.foxess_modbus.entities.validation import BaseValidator
 from homeassistant.components.number import NumberEntity
 from homeassistant.components.number import NumberEntityDescription
 from homeassistant.components.number import NumberMode
@@ -12,6 +11,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity import Entity
 
 from ..common.entity_controller import EntityController
+from .base_validator import BaseValidator
 from .entity_factory import EntityFactory
 from .modbus_entity_mixin import ModbusEntityMixin
 

--- a/custom_components/foxess_modbus/entities/modbus_select.py
+++ b/custom_components/foxess_modbus/entities/modbus_select.py
@@ -3,13 +3,13 @@ import logging
 from dataclasses import dataclass
 from dataclasses import field
 
-from custom_components.foxess_modbus.entities.validation import BaseValidator
 from homeassistant.components.select import SelectEntity
 from homeassistant.components.select import SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity import Entity
 
 from ..common.entity_controller import EntityController
+from .base_validator import BaseValidator
 from .entity_factory import EntityFactory
 from .modbus_entity_mixin import ModbusEntityMixin
 

--- a/custom_components/foxess_modbus/entities/modbus_sensor.py
+++ b/custom_components/foxess_modbus/entities/modbus_sensor.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from dataclasses import field
 from typing import Callable
 
-from custom_components.foxess_modbus.entities.validation import BaseValidator
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.components.sensor import SensorStateClass
@@ -12,6 +11,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity import Entity
 
 from ..common.entity_controller import EntityController
+from .base_validator import BaseValidator
 from .entity_factory import EntityFactory
 from .modbus_entity_mixin import ModbusEntityMixin
 

--- a/custom_components/foxess_modbus/entities/validation.py
+++ b/custom_components/foxess_modbus/entities/validation.py
@@ -1,14 +1,6 @@
 """Validation"""
-from abc import ABC
-from abc import abstractmethod
-
-
-class BaseValidator(ABC):
-    """Base validator"""
-
-    @abstractmethod
-    def validate(self, data) -> bool:
-        """Validate a value against a set of rules"""
+from .base_validator import BaseValidator
+from .modbus_charge_period_sensors import is_time_value_valid
 
 
 class Range(BaseValidator):
@@ -56,5 +48,4 @@ class Time(BaseValidator):
 
     def validate(self, data) -> bool:
         """Validate a value against a set of rules"""
-        hours, minutes = ((data & 0xFF00) >> 8, data & 0xFF)
-        return 0 <= hours <= 23 and 0 <= minutes <= 59
+        return is_time_value_valid(data)

--- a/custom_components/foxess_modbus/services.yaml
+++ b/custom_components/foxess_modbus/services.yaml
@@ -33,10 +33,11 @@ update_charge_period:
   description: >
     Updates one of the two charge periods (if supported by your inverter).
   fields:
-    device:
+    inverter:
       name: Inverter
       description: Which inverter to target.
       required: true
+      example: ""
       selector:
         device:
           device_class: "battery_charging"
@@ -44,6 +45,7 @@ update_charge_period:
       name: Charge Period
       description: Which charge period to update.
       required: true
+      example: 1
       selector:
         select:
           options:
@@ -55,12 +57,14 @@ update_charge_period:
       name: Enable force charge
       description: Whether to enable this force charge window.
       required: true
+      example: true
       selector:
         boolean:
     enable_charge_from_grid:
       name: Enable charge from grid
       description: Whether to charge the battery from the grid, or just prevent discharge.
       required: true
+      example: false
       selector:
         boolean:
     start:
@@ -68,7 +72,7 @@ update_charge_period:
       description: >
         The start of the charge period. This is only required if 'Enable force charge' is selected.
       required: true
-      default: "02:00:00"
+      example: "02:00:00"
       selector:
         time:
     end:
@@ -78,6 +82,6 @@ update_charge_period:
 
         This may not be less than or equal to 'Start' (time periods may not span midnight).
       required: true
-      default: "05:00:00"
+      example: "05:00:00"
       selector:
         time:

--- a/custom_components/foxess_modbus/services.yaml
+++ b/custom_components/foxess_modbus/services.yaml
@@ -4,13 +4,13 @@ write_registers:
   description: >
     Writes one or more registers
   fields:
-    friendly_name:
-      name: Friendly Name
-      description: Unique friendly name
-      example: "inverter_name"
-      default: "inverter_name"
+    inverter:
+      name: Inverter
+      description: Which inverter to target. Pass a device ID or unique friendly name.
+      required: true
+      example: ""
       selector:
-        text:
+        device:
     start_address:
       name: Start Address
       description: Start address to write to
@@ -35,7 +35,7 @@ update_charge_period:
   fields:
     inverter:
       name: Inverter
-      description: Which inverter to target.
+      description: Which inverter to target. Pass a device ID or unique friendly name.
       required: true
       example: ""
       selector:

--- a/custom_components/foxess_modbus/services.yaml
+++ b/custom_components/foxess_modbus/services.yaml
@@ -8,7 +8,8 @@ write_registers:
       name: Inverter
       description: Which inverter to target. Pass a device ID or unique friendly name.
       required: true
-      example: ""
+      default: "''"
+      example: "''"
       selector:
         device:
     start_address:
@@ -37,7 +38,8 @@ update_charge_period:
       name: Inverter
       description: Which inverter to target. Pass a device ID or unique friendly name.
       required: true
-      example: ""
+      default: "''"
+      example: "''"
       selector:
         device:
           device_class: "battery_charging"

--- a/custom_components/foxess_modbus/services.yaml
+++ b/custom_components/foxess_modbus/services.yaml
@@ -92,3 +92,32 @@ update_charge_period:
       example: "05:00:00"
       selector:
         time:
+update_all_charge_periods:
+  name: Update All Charge Periods
+  description: Sets all charge periods in one service call. The service "Update Charge Period" is easier for end-users to use.
+  fields:
+    inverter:
+      name: Inverter
+      description: Which inverter to target. Pass a device ID or unique friendly name.
+      required: true
+      default: "''"
+      example: "''"
+      selector:
+        device:
+          integration: foxess_modbus
+          entity:
+            device_class: "battery_charging"
+    charge_periods:
+      name: Charge Periods
+      description: Charge periods to set. This should be an array of objects, one for each charge period. All charge periods must be specified. See the example data
+      required: true
+      default: ""
+      example: >
+        - enable_force_charge: true
+          enable_charge_from_grid: true
+          start: "01:00"
+          end: "03:00"
+        - enable_force_charge: false
+          enable_charge_from_grid: false
+      selector:
+        object:

--- a/custom_components/foxess_modbus/services.yaml
+++ b/custom_components/foxess_modbus/services.yaml
@@ -12,6 +12,7 @@ write_registers:
       example: "''"
       selector:
         device:
+          integration: foxess_modbus
     start_address:
       name: Start Address
       description: Start address to write to
@@ -42,19 +43,21 @@ update_charge_period:
       example: "''"
       selector:
         device:
-          device_class: "battery_charging"
+          integration: foxess_modbus
+          entity:
+            device_class: "battery_charging"
     charge_period:
       name: Charge Period
       description: Which charge period to update.
       required: true
-      example: 1
+      example: "'1'"
       selector:
         select:
           options:
             - label: Time period 1
-              value: 1
+              value: "1"
             - label: Time period 2
-              value: 2
+              value: "2"
     enable_force_charge:
       name: Enable force charge
       description: Whether to enable this force charge window.

--- a/custom_components/foxess_modbus/services.yaml
+++ b/custom_components/foxess_modbus/services.yaml
@@ -72,6 +72,7 @@ update_charge_period:
       description: >
         The start of the charge period. This is only required if 'Enable force charge' is selected.
       required: true
+      default: "02:00:00"
       example: "02:00:00"
       selector:
         time:
@@ -82,6 +83,7 @@ update_charge_period:
 
         This may not be less than or equal to 'Start' (time periods may not span midnight).
       required: true
+      default: "05:00:00"
       example: "05:00:00"
       selector:
         time:

--- a/custom_components/foxess_modbus/services.yaml
+++ b/custom_components/foxess_modbus/services.yaml
@@ -64,7 +64,7 @@ update_charge_period:
       selector:
         boolean:
     start:
-      name: Start
+      name: Period Start
       description: >
         The start of the charge period. This is only required if 'Enable force charge' is selected.
       required: true
@@ -72,7 +72,7 @@ update_charge_period:
       selector:
         time:
     end:
-      name: End
+      name: Period End
       description: >
         The end of the charge period. This is only required of 'Enable force charge' is selected.
 

--- a/custom_components/foxess_modbus/services.yaml
+++ b/custom_components/foxess_modbus/services.yaml
@@ -28,3 +28,56 @@ write_registers:
       default: "1, 2, 3"
       selector:
         text:
+update_charge_period:
+  name: Update Charge Period
+  description: >
+    Updates one of the two charge periods (if supported by your inverter).
+  fields:
+    device:
+      name: Inverter
+      description: Which inverter to target.
+      required: true
+      selector:
+        device:
+          device_class: "battery_charging"
+    charge_period:
+      name: Charge Period
+      description: Which charge period to update.
+      required: true
+      selector:
+        select:
+          options:
+            - label: Time period 1
+              value: 1
+            - label: Time period 2
+              value: 2
+    enable_force_charge:
+      name: Enable force charge
+      description: Whether to enable this force charge window.
+      required: true
+      selector:
+        boolean:
+    enable_charge_from_grid:
+      name: Enable charge from grid
+      description: Whether to charge the battery from the grid, or just prevent discharge.
+      required: true
+      selector:
+        boolean:
+    start:
+      name: Start
+      description: >
+        The start of the charge period. This is only required if 'Enable force charge' is selected.
+      required: true
+      default: "02:00:00"
+      selector:
+        time:
+    end:
+      name: End
+      description: >
+        The end of the charge period. This is only required of 'Enable force charge' is selected.
+
+        This may not be less than or equal to 'Start' (time periods may not span midnight).
+      required: true
+      default: "05:00:00"
+      selector:
+        time:

--- a/custom_components/foxess_modbus/services/update_charge_period_service.py
+++ b/custom_components/foxess_modbus/services/update_charge_period_service.py
@@ -7,6 +7,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.core import ServiceCall
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
+from pymodbus.exceptions import ModbusIOException
 
 from ..const import DOMAIN
 from ..entities.modbus_charge_period_sensors import is_time_value_valid
@@ -187,4 +188,8 @@ async def _handler(
 
     assert not any(x for x in write_values if x is None)
 
-    await controller.write_registers(write_start_address, write_values)
+    try:
+        await controller.write_registers(write_start_address, write_values)
+    except ModbusIOException as ex:
+        _LOGGER.warning(ex, exc_info=1)
+        raise HomeAssistantError() from ex

--- a/custom_components/foxess_modbus/services/update_charge_period_service.py
+++ b/custom_components/foxess_modbus/services/update_charge_period_service.py
@@ -2,11 +2,13 @@ from typing import Any
 import voluptuous as vol
 import asyncio
 import logging
+from datetime import time
 
 from pymodbus.exceptions import ModbusIOException
 
 from homeassistant.helpers import config_validation as cv
 from homeassistant.core import HomeAssistant
+from homeassistant.core import ServiceCall
 
 from ..const import DOMAIN
 from ..const import FRIENDLY_NAME
@@ -14,12 +16,44 @@ from ..modbus_controller import ModbusController
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
-_WRITE_SCHEMA = vol.Schema(
-    {
-        vol.Required("friendly_name", description="Friendly Name"): cv.string,
-        vol.Required("start_address", description="Start Address"): int,
-        vol.Required("values", description="Values"): cv.string,
-    }
+
+def _start_end_must_be_present_if_enabled(data):
+    if data["enable_force_charge"]:
+        if not "start" in data:
+            raise vol.Invalid(
+                "'start' must be specified if 'enable_force_charge' is True"
+            )
+        if not "end" in data:
+            raise vol.Invalid(
+                "'end' must be specified if 'enable_force_charge' is True"
+            )
+
+
+def _end_must_be_after_start(data):
+    pass
+
+
+_SCHEMA = vol.Schema(
+    vol.All(
+        {
+            vol.Required("device", description="Inverter"): cv.string,
+            vol.Required("charge_period", description="Charge Period"): vol.All(
+                int, vol.Range(min=0, max=1)
+            ),
+            vol.Required(
+                "enable_force_charge", description="Enable force charge"
+            ): cv.boolean,
+            vol.Required(
+                "enable_charge_from_grid", description="Enable charge from grid"
+            ): cv.boolean,
+            vol.Optional("start", description="Period Start"): cv.time,
+            vol.Optional("end", description="Period End"): vol.All(
+                cv.time, vol.Range(min=time(hour=0, minute=1))
+            ),
+        },
+        _start_end_must_be_present_if_enabled,
+        _end_must_be_after_start,
+    )
 )
 
 
@@ -29,6 +63,14 @@ def register(
     hass.services.async_register(
         DOMAIN,
         "update_charge_period",
-        lambda data: None,
-        _WRITE_SCHEMA,
+        lambda data: asyncio.run_coroutine_threadsafe(
+            _handler(inverter_controllers, data), hass.loop
+        ),
+        _SCHEMA,
     )
+
+
+async def _handler(
+    mapping: list[tuple[Any, ModbusController]], service_data: ServiceCall
+) -> None:
+    raise Exception("NOOOOO")

--- a/custom_components/foxess_modbus/services/update_charge_period_service.py
+++ b/custom_components/foxess_modbus/services/update_charge_period_service.py
@@ -136,16 +136,15 @@ async def _handler(
                 charge_period.period_start_address
             )
             period_end_time_value = controller.read(charge_period.period_end_address)
-            writes.append((charge_period.period_start_address, period_start_time_value))
-            writes.append((charge_period.period_end_address, period_end_time_value))
-            writes.append(
-                (
-                    charge_period.enable_charge_from_grid_address,
-                    controller.read(charge_period.enable_charge_from_grid_address),
-                )
+            period_enable_charge_from_grid_value = controller.read(
+                charge_period.enable_charge_from_grid_address
             )
 
-            if period_start_time_value is None or period_end_time_value is None:
+            if (
+                period_start_time_value is None
+                or period_end_time_value is None
+                or period_enable_charge_from_grid_value is None
+            ):
                 raise HomeAssistantError(
                     f"Data for charge period {i + 1} is not available. Please try again in a few seconds"
                 )
@@ -155,6 +154,15 @@ async def _handler(
                 raise HomeAssistantError(
                     f"Start time '{period_start_time_value}' or end time '{period_end_time_value}' for charge period {i + 1} is not valid"
                 )
+
+            writes.append((charge_period.period_start_address, period_start_time_value))
+            writes.append((charge_period.period_end_address, period_end_time_value))
+            writes.append(
+                (
+                    charge_period.enable_charge_from_grid_address,
+                    period_enable_charge_from_grid_value,
+                )
+            )
 
             if enable_force_charge:
                 period_start_time = parse_time_value(period_start_time_value)

--- a/custom_components/foxess_modbus/services/update_charge_period_service.py
+++ b/custom_components/foxess_modbus/services/update_charge_period_service.py
@@ -1,0 +1,34 @@
+from typing import Any
+import voluptuous as vol
+import asyncio
+import logging
+
+from pymodbus.exceptions import ModbusIOException
+
+from homeassistant.helpers import config_validation as cv
+from homeassistant.core import HomeAssistant
+
+from ..const import DOMAIN
+from ..const import FRIENDLY_NAME
+from ..modbus_controller import ModbusController
+
+_LOGGER: logging.Logger = logging.getLogger(__package__)
+
+_WRITE_SCHEMA = vol.Schema(
+    {
+        vol.Required("friendly_name", description="Friendly Name"): cv.string,
+        vol.Required("start_address", description="Start Address"): int,
+        vol.Required("values", description="Values"): cv.string,
+    }
+)
+
+
+def register(
+    hass: HomeAssistant, inverter_controllers: list[tuple[Any, ModbusController]]
+) -> None:
+    hass.services.async_register(
+        DOMAIN,
+        "update_charge_period",
+        lambda data: None,
+        _WRITE_SCHEMA,
+    )

--- a/custom_components/foxess_modbus/services/update_charge_period_service.py
+++ b/custom_components/foxess_modbus/services/update_charge_period_service.py
@@ -1,4 +1,5 @@
 import logging
+from dataclasses import dataclass
 from datetime import time
 from typing import Any
 
@@ -64,7 +65,7 @@ def _end_must_be_after_start(data: dict[str, Any]) -> dict[str, Any]:
     return data
 
 
-_SCHEMA = vol.Schema(
+_UPDATE_CHARGE_PERIOD_SCHEMA = vol.Schema(
     vol.All(
         {
             # Let the value to this be omitted, instead of forcing them to specify ''
@@ -90,25 +91,104 @@ _SCHEMA = vol.Schema(
     )
 )
 
+_UPDATE_ALL_CHARGE_PERIODS_SCHEMA = vol.Schema(
+    {
+        # Let the value to this be omitted, instead of forcing them to specify ''
+        vol.Required("inverter", description="Inverter"): vol.Any(cv.string, None),
+        vol.Required("charge_periods", description="Charge Periods"): vol.All(
+            [
+                vol.All(
+                    {
+                        vol.Required(
+                            "enable_force_charge", description="Enable force charge"
+                        ): cv.boolean,
+                        vol.Required(
+                            "enable_charge_from_grid",
+                            description="Enable charge from grid",
+                        ): cv.boolean,
+                        vol.Optional("start", description="Period Start"): vol.All(
+                            cv.time, _seconds_must_be_zero
+                        ),
+                        vol.Optional("end", description="Period End"): vol.All(
+                            cv.time,
+                            vol.Range(min=time(hour=0, minute=1)),
+                            _seconds_must_be_zero,
+                        ),
+                    },
+                    _start_end_must_be_present_if_enabled,
+                    _end_must_be_after_start,
+                )
+            ],
+            vol.Length(min=2, max=2),
+        ),
+    }
+)
+
 
 def register(
     hass: HomeAssistant, inverter_controllers: list[tuple[Any, ModbusController]]
 ) -> None:
     """Register the service with HA"""
 
-    async def _callback(service_data: ServiceCall):
-        await hass.loop.create_task(_handler(inverter_controllers, service_data, hass))
+    async def _update_charge_period_callback(service_data: ServiceCall):
+        await hass.loop.create_task(
+            _update_charge_period(inverter_controllers, service_data, hass)
+        )
 
     hass.services.async_register(
         DOMAIN,
         "update_charge_period",
-        _callback,
-        _SCHEMA,
+        _update_charge_period_callback,
+        _UPDATE_CHARGE_PERIOD_SCHEMA,
+    )
+
+    async def _update_all_charge_periods_callback(service_data: ServiceCall):
+        await hass.loop.create_task(
+            _update_all_charge_periods(inverter_controllers, service_data, hass)
+        )
+
+    hass.services.async_register(
+        DOMAIN,
+        "update_all_charge_periods",
+        _update_all_charge_periods_callback,
+        _UPDATE_ALL_CHARGE_PERIODS_SCHEMA,
     )
 
 
-# pylint: disable-next=too-many-locals
-async def _handler(
+@dataclass
+class ChargePeriod:
+    """Holds the data for a single charge period"""
+
+    enable_force_charge: bool
+    enable_charge_from_grid: bool
+    start: time
+    end: time
+
+
+async def _update_all_charge_periods(
+    mapping: list[tuple[Any, ModbusController]],
+    service_data: ServiceCall,
+    hass: HomeAssistant,
+) -> None:
+    controller = get_controller_from_friendly_name_or_device_id(
+        service_data.data["inverter"], mapping, hass
+    )
+
+    charge_periods: list[ChargePeriod] = []
+    for charge_period in service_data.data["charge_periods"]:
+        charge_periods.append(
+            ChargePeriod(
+                enable_force_charge=charge_period["enable_force_charge"],
+                enable_charge_from_grid=charge_period["enable_charge_from_grid"],
+                start=charge_period.get("start", time(hour=0, minute=0)),
+                end=charge_period.get("end", time(hour=0, minute=0)),
+            )
+        )
+
+    await _set_charge_periods(controller, charge_periods)
+
+
+async def _update_charge_period(
     mapping: list[tuple[Any, ModbusController]],
     service_data: ServiceCall,
     hass: HomeAssistant,
@@ -117,91 +197,113 @@ async def _handler(
         service_data.data["inverter"], mapping, hass
     )
     charge_period_index = service_data.data["charge_period"] - 1
-    enable_force_charge = service_data.data["enable_force_charge"]
-    enable_charge_from_grid = service_data.data["enable_charge_from_grid"]
-    start_time = service_data.data["start"]
-    end_time = service_data.data["end"]
 
+    type_profile = controller.connection_type_profile
+
+    charge_periods = [
+        ChargePeriod(
+            enable_force_charge=service_data.data["enable_force_charge"],
+            enable_charge_from_grid=service_data.data["enable_charge_from_grid"],
+            start=service_data.data.get("start", time(hour=0, minute=0)),
+            end=service_data.data.get("end", time(hour=0, minute=0)),
+        )
+    ]
+
+    # Add the other charge periods, which aren't being set right now, to charge_periods
+    for i, charge_period in enumerate(type_profile.charge_periods):
+        if i == charge_period_index:
+            continue
+
+        period_start_time_value = controller.read(charge_period.period_start_address)
+        period_end_time_value = controller.read(charge_period.period_end_address)
+        period_enable_charge_from_grid_value = controller.read(
+            charge_period.enable_charge_from_grid_address
+        )
+
+        if (
+            period_start_time_value is None
+            or period_end_time_value is None
+            or period_enable_charge_from_grid_value is None
+        ):
+            raise HomeAssistantError(
+                f"Data for charge period {i + 1} is not available. Please try again in a few seconds"
+            )
+        if not is_time_value_valid(period_start_time_value) or not is_time_value_valid(
+            period_end_time_value
+        ):
+            raise HomeAssistantError(
+                f"Start time '{period_start_time_value}' or end time '{period_end_time_value}' for charge period {i + 1} is not valid"
+            )
+
+        charge_periods.append(
+            ChargePeriod(
+                enable_force_charge=period_start_time_value > 0
+                or period_end_time_value > 0,
+                enable_charge_from_grid=period_enable_charge_from_grid_value > 0,
+                start=parse_time_value(period_start_time_value),
+                end=parse_time_value(period_end_time_value),
+            )
+        )
+
+    await _set_charge_periods(controller, charge_periods)
+
+
+async def _set_charge_periods(
+    controller: ModbusController, charge_periods: list[ChargePeriod]
+) -> None:
     type_profile = controller.connection_type_profile
 
     if len(type_profile.charge_periods) == 0:
         raise HomeAssistantError("Inverter does not support setting charge periods")
-    if charge_period_index >= len(type_profile.charge_periods):
+    if len(charge_periods) > len(type_profile.charge_periods):
         raise HomeAssistantError(
-            f"Inverter does not support setting charge period {charge_period_index + 1}"
+            f"Inverter does not support setting charge period {len(type_profile.charge_periods)}"
+        )
+    if len(charge_periods) < len(type_profile.charge_periods):
+        raise HomeAssistantError(
+            f"Entries must be provided for all charge periods. Expected {len(type_profile.charge_periods)} "
+            + f"charge periods, got {len(charge_periods)}"
         )
 
-    assert 0 <= charge_period_index < len(type_profile.charge_periods)
+    # Make sure that none of the charge periods overlap. Sort by start time, then ensure each doesn't overlap the next
+    sorted_enabled_periods = sorted(
+        (x for x in charge_periods if x.enable_force_charge), key=lambda x: x.start
+    )
+    for i, charge_period in enumerate(sorted_enabled_periods):
+        if i == 0:
+            continue
+        previous = sorted_enabled_periods[i - 1]
+        # It's permissible to have two periods which have the same start/end time (at least the foxcloud app allows it)
+        if charge_period.start < previous.end and previous.start < charge_period.end:
+            raise HomeAssistantError(
+                f"Charge period {i} {previous.start}-{previous.end} overlaps charge period {i + 1} {charge_period.start}-{charge_period.end}"
+            )
 
     # List of (address, value)
     writes: list[tuple[int, int]] = []
-
-    for i, charge_period in enumerate(type_profile.charge_periods):
-        if i != charge_period_index:
-            period_start_time_value = controller.read(
-                charge_period.period_start_address
+    for charge_period, config in zip(charge_periods, type_profile.charge_periods):
+        writes.append(
+            (
+                config.period_start_address,
+                serialize_time_to_value(charge_period.start)
+                if charge_period.enable_force_charge
+                else 0,
             )
-            period_end_time_value = controller.read(charge_period.period_end_address)
-            period_enable_charge_from_grid_value = controller.read(
-                charge_period.enable_charge_from_grid_address
+        )
+        writes.append(
+            (
+                config.period_end_address,
+                serialize_time_to_value(charge_period.end)
+                if charge_period.enable_force_charge
+                else 0,
             )
-
-            if (
-                period_start_time_value is None
-                or period_end_time_value is None
-                or period_enable_charge_from_grid_value is None
-            ):
-                raise HomeAssistantError(
-                    f"Data for charge period {i + 1} is not available. Please try again in a few seconds"
-                )
-            if not is_time_value_valid(
-                period_start_time_value
-            ) or not is_time_value_valid(period_end_time_value):
-                raise HomeAssistantError(
-                    f"Start time '{period_start_time_value}' or end time '{period_end_time_value}' for charge period {i + 1} is not valid"
-                )
-
-            writes.append((charge_period.period_start_address, period_start_time_value))
-            writes.append((charge_period.period_end_address, period_end_time_value))
-            writes.append(
-                (
-                    charge_period.enable_charge_from_grid_address,
-                    period_enable_charge_from_grid_value,
-                )
+        )
+        writes.append(
+            (
+                config.enable_charge_from_grid_address,
+                1 if charge_period.enable_charge_from_grid else 0,
             )
-
-            # Make sure that this charge period does not overlap the one being set
-            if enable_force_charge:
-                period_start_time = parse_time_value(period_start_time_value)
-                period_end_time = parse_time_value(period_end_time_value)
-
-                # It's permissible to have two periods which have the same start/end time (at least the foxcloud app allows it)
-                if period_start_time < end_time and start_time < period_end_time:
-                    raise HomeAssistantError(
-                        f"Specified period {start_time}-{end_time} overlaps existing charge period {i + 1} {period_start_time}-{period_end_time}"
-                    )
-
-    # We expect enable_charge_from_grid, start, end to be next to each other, in that order
-    charge_period = type_profile.charge_periods[charge_period_index]
-
-    writes.append(
-        (
-            charge_period.period_start_address,
-            serialize_time_to_value(start_time) if enable_force_charge else 0,
         )
-    )
-    writes.append(
-        (
-            charge_period.period_end_address,
-            serialize_time_to_value(end_time) if enable_force_charge else 0,
-        )
-    )
-    writes.append(
-        (
-            charge_period.enable_charge_from_grid_address,
-            1 if enable_charge_from_grid else 0,
-        )
-    )
 
     # We expect all of the writes to have a contiguous set of addresses
     write_values = [None] * len(writes)

--- a/custom_components/foxess_modbus/services/update_charge_period_service.py
+++ b/custom_components/foxess_modbus/services/update_charge_period_service.py
@@ -19,6 +19,18 @@ from .utils import get_controller_from_friendly_name_or_device_id
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 
+def _integer(value: Any) -> int:
+    """Validate and coerce a boolean value."""
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            pass
+    raise vol.Invalid(f"invalid int value {value}")
+
+
 def _seconds_must_be_zero(value: time) -> time:
     if value.second != 0:
         raise vol.Invalid("Seconds component must be 0 if specified")
@@ -58,7 +70,7 @@ _SCHEMA = vol.Schema(
             # Let the value to this be omitted, instead of forcing them to specify ''
             vol.Required("inverter", description="Inverter"): vol.Any(cv.string, None),
             vol.Required("charge_period", description="Charge Period"): vol.All(
-                int, vol.Range(min=1, max=2)
+                _integer, vol.Range(min=1, max=2)
             ),
             vol.Required(
                 "enable_force_charge", description="Enable force charge"

--- a/custom_components/foxess_modbus/services/update_charge_period_service.py
+++ b/custom_components/foxess_modbus/services/update_charge_period_service.py
@@ -17,20 +17,37 @@ from ..modbus_controller import ModbusController
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 
-def _start_end_must_be_present_if_enabled(data):
+def _seconds_must_be_zero(value: time) -> time:
+    if value.second != 0:
+        raise vol.Invalid("Seconds component must be 0 if specified")
+    return value
+
+
+def _start_end_must_be_present_if_enabled(data: dict[str, Any]) -> dict[str, Any]:
     if data["enable_force_charge"]:
         if not "start" in data:
             raise vol.Invalid(
-                "'start' must be specified if 'enable_force_charge' is True"
+                "'start' must be specified if 'enable_force_charge' is True",
+                path=["start"],
             )
         if not "end" in data:
             raise vol.Invalid(
-                "'end' must be specified if 'enable_force_charge' is True"
+                "'end' must be specified if 'enable_force_charge' is True", path=["end"]
             )
+    return data
 
 
-def _end_must_be_after_start(data):
-    pass
+def _end_must_be_after_start(data: dict[str, Any]) -> dict[str, Any]:
+    if "start" in data and "end" in data:
+        start = data["start"]
+        end = data["end"]
+        if end.hour < start.hour or (
+            end.hour == start.hour and end.minute <= start.minute
+        ):
+            raise vol.Invalid(
+                "'end' must be at least 1 minute after 'start'", path=["end"]
+            )
+    return data
 
 
 _SCHEMA = vol.Schema(
@@ -46,9 +63,11 @@ _SCHEMA = vol.Schema(
             vol.Required(
                 "enable_charge_from_grid", description="Enable charge from grid"
             ): cv.boolean,
-            vol.Optional("start", description="Period Start"): cv.time,
+            vol.Optional("start", description="Period Start"): vol.All(
+                cv.time, _seconds_must_be_zero
+            ),
             vol.Optional("end", description="Period End"): vol.All(
-                cv.time, vol.Range(min=time(hour=0, minute=1))
+                cv.time, vol.Range(min=time(hour=0, minute=1)), _seconds_must_be_zero
             ),
         },
         _start_end_must_be_present_if_enabled,

--- a/custom_components/foxess_modbus/services/update_charge_period_service.py
+++ b/custom_components/foxess_modbus/services/update_charge_period_service.py
@@ -9,6 +9,7 @@ from pymodbus.exceptions import ModbusIOException
 from homeassistant.helpers import config_validation as cv
 from homeassistant.core import HomeAssistant
 from homeassistant.core import ServiceCall
+from homeassistant.exceptions import HomeAssistantError
 
 from ..const import DOMAIN
 from ..const import FRIENDLY_NAME
@@ -79,17 +80,21 @@ _SCHEMA = vol.Schema(
 def register(
     hass: HomeAssistant, inverter_controllers: list[tuple[Any, ModbusController]]
 ) -> None:
+    async def _callback(service_data: ServiceCall):
+        await hass.loop.create_task(_handler(inverter_controllers, service_data))
+
     hass.services.async_register(
         DOMAIN,
         "update_charge_period",
-        lambda data: asyncio.run_coroutine_threadsafe(
-            _handler(inverter_controllers, data), hass.loop
-        ),
+        _callback,
         _SCHEMA,
     )
 
 
 async def _handler(
-    mapping: list[tuple[Any, ModbusController]], service_data: ServiceCall
+    mapping: list[tuple[Any, ModbusController]],
+    service_data: ServiceCall,
 ) -> None:
-    raise Exception("NOOOOO")
+    await asyncio.sleep(0.1)
+    _LOGGER.warning("OH NOES!!")
+    raise HomeAssistantError("Something something nooo")

--- a/custom_components/foxess_modbus/services/utils.py
+++ b/custom_components/foxess_modbus/services/utils.py
@@ -1,0 +1,48 @@
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry
+
+from ..const import FRIENDLY_NAME
+from ..modbus_controller import ModbusController
+
+
+def get_controller_from_friendly_name_or_device_id(
+    device_id: str | None,
+    inverter_controllers: list[tuple[Any, ModbusController]],
+    hass: HomeAssistant,
+) -> ModbusController:
+    if device_id is None:
+        device_id = ""
+
+    # See if there's a device with this ID first
+    registry = device_registry.async_get(hass)
+    device = registry.devices.get(device_id)
+    if device is not None:
+        identifiers = device.identifiers
+        assert len(identifiers) == 1
+        (parts,) = identifiers
+        friendly_name = parts[3]
+    else:
+        # No? OK, they probably specified a friendly name
+        friendly_name = device_id
+
+    modbus_controller = next(
+        (
+            controller
+            for (inverter, controller) in inverter_controllers
+            if inverter[FRIENDLY_NAME] == friendly_name
+        ),
+        None,
+    )
+
+    if modbus_controller is None:
+        friendly_names = ", ".join(
+            f"'{inverter[FRIENDLY_NAME]}'" for (inverter, _) in inverter_controllers
+        )
+        raise HomeAssistantError(
+            f"Unable to find an inverter with the device ID or friendly name '{friendly_name}'. Valid friendly names: {friendly_names}"
+        )
+
+    return modbus_controller

--- a/custom_components/foxess_modbus/services/write_registers_service.py
+++ b/custom_components/foxess_modbus/services/write_registers_service.py
@@ -1,56 +1,76 @@
-import asyncio
 import logging
 from typing import Any
 
 import voluptuous as vol
 from homeassistant.core import HomeAssistant
 from homeassistant.core import ServiceCall
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from pymodbus.exceptions import ModbusIOException
 
 from ..const import DOMAIN
-from ..const import FRIENDLY_NAME
 from ..modbus_controller import ModbusController
+from .utils import get_controller_from_friendly_name_or_device_id
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
+
+def _must_specify_either_interver_or_friendly_name(
+    data: dict[str, Any]
+) -> dict[str, Any]:
+    if "inverter" not in data and "friendly_name" not in data:
+        raise vol.Invalid("required key not provided", path=["inverter"])
+    return data
+
+
 _WRITE_SCHEMA = vol.Schema(
-    {
-        vol.Optional("friendly_name", description="Friendly Name"): cv.string,
-        vol.Required("start_address", description="Start Address"): int,
-        vol.Required("values", description="Values"): cv.string,
-    }
+    vol.All(
+        {
+            # We require either inverter or friendly_name (legacy)
+            # Let the value to this be omitted, instead of forcing them to specify ''
+            vol.Optional("inverter", description="Inverter"): vol.Any(cv.string, None),
+            vol.Optional("friendly_name", description="Friendly Name"): cv.string,
+            vol.Required("start_address", description="Start Address"): int,
+            vol.Required("values", description="Values"): cv.string,
+        },
+        _must_specify_either_interver_or_friendly_name,
+    )
 )
 
 
 def register(
     hass: HomeAssistant, inverter_controllers: list[tuple[Any, ModbusController]]
 ) -> None:
+    async def _callback(service_data: ServiceCall):
+        await hass.loop.create_task(
+            _write_service(inverter_controllers, service_data, hass)
+        )
+
     hass.services.async_register(
         DOMAIN,
         "write_registers",
-        lambda data: asyncio.run_coroutine_threadsafe(
-            _write_service(inverter_controllers, data), hass.loop
-        ),
+        _callback,
         _WRITE_SCHEMA,
     )
 
 
 async def _write_service(
-    mapping: list[tuple[Any, ModbusController]], service_data: ServiceCall
+    mapping: list[tuple[Any, ModbusController]],
+    service_data: ServiceCall,
+    hass: HomeAssistant,
 ):
     """Write service"""
+    # Support both for backwards compatibility
+    inverter_id = service_data.data.get("inverter")
+    friendly_name = service_data.data.get("friendly_name")
+    controller = get_controller_from_friendly_name_or_device_id(
+        inverter_id if inverter_id is not None else friendly_name, mapping, hass
+    )
+
     try:
-        friendly_name = service_data.data.get(FRIENDLY_NAME, "")
-        for inverter, controller in mapping:
-            if inverter[FRIENDLY_NAME] == friendly_name:
-                if {"start_address", "values"} <= set(service_data.data):
-                    start_address = service_data.data["start_address"]
-                    values = service_data.data["values"].split(",")
-                    await controller.write_registers(start_address, values)
-                else:
-                    _LOGGER.warning(
-                        "Modbus write service called with incorrect data format"
-                    )
+        start_address = service_data.data["start_address"]
+        values = service_data.data["values"].split(",")
+        await controller.write_registers(start_address, values)
     except ModbusIOException as ex:
         _LOGGER.warning(ex, exc_info=1)
+        raise HomeAssistantError() from ex

--- a/custom_components/foxess_modbus/services/write_registers_service.py
+++ b/custom_components/foxess_modbus/services/write_registers_service.py
@@ -1,0 +1,50 @@
+from typing import Any
+import voluptuous as vol
+import asyncio
+import logging
+
+from pymodbus.exceptions import ModbusIOException
+
+from homeassistant.helpers import config_validation as cv
+from homeassistant.core import HomeAssistant
+from homeassistant.core import ServiceCall
+
+from ..const import DOMAIN
+from ..const import FRIENDLY_NAME
+from ..modbus_controller import ModbusController
+
+_LOGGER: logging.Logger = logging.getLogger(__package__)
+
+_WRITE_SCHEMA = vol.Schema(
+    {
+        vol.Optional("friendly_name", description="Friendly Name"): cv.string,
+        vol.Required("start_address", description="Start Address"): int,
+        vol.Required("values", description="Values"): cv.string,
+    }
+)
+
+
+def register(
+    hass: HomeAssistant, inverter_controllers: list[tuple[Any, ModbusController]]
+) -> None:
+    hass.services.async_register(
+        DOMAIN,
+        "write_registers",
+        lambda data: asyncio.run_coroutine_threadsafe(
+            _write_service(inverter_controllers, data), hass.loop
+        ),
+        _WRITE_SCHEMA,
+    )
+
+
+async def _write_service(
+    mapping: list[tuple[Any, ModbusController]], service_data: ServiceCall
+):
+    """Write service"""
+    try:
+        friendly_name = service_data.data.get(FRIENDLY_NAME, "")
+        for inverter, controller in mapping:
+            if inverter[FRIENDLY_NAME] == friendly_name:
+                await controller.write(service_data)
+    except ModbusIOException as ex:
+        _LOGGER.warning(ex, exc_info=1)


### PR DESCRIPTION
Add a new service which can update one of the two charge windows. This ensures that the time period being written is valid:

 * Just consists of hours and minutes
 * In the range 00:00 -> 23:59
 * End is > start
 * Period does not overlap any other periods configured on the inverter

It then gathers together all time periods, and writes them in a single write.

![image](https://user-images.githubusercontent.com/568104/229544772-00ab4d4a-ef57-41b1-965e-a38e24611eb8.png)

The inverter can be specified either using a drop-down in the GUI, or by providing a friendly name. This also updates the existing "write_registers" service to follow the same scheme.