### PR TITLE
Fix issues around modbus TCP connections/reconnections

### DIFF
--- a/custom_components/foxess_modbus/config_flow.py
+++ b/custom_components/foxess_modbus/config_flow.py
@@ -228,7 +228,7 @@ class ModbusFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 params.update({"host": host.split(":")[0], "port": host.split(":")[1]})
             else:
                 params.update({"port": host, "baudrate": 9600})
-            client = ModbusClient(self.hass, params, False)
+            client = ModbusClient(self.hass, params)
             return (True, await ModbusController.autodetect(client, slave))
         except UnsupportedInverterException as ex:
             _LOGGER.warning(f"{ex}")

--- a/custom_components/foxess_modbus/modbus_controller.py
+++ b/custom_components/foxess_modbus/modbus_controller.py
@@ -114,7 +114,6 @@ class ModbusController(EntityController, UnloadController):
         """
         for conn_type_name, conn_type in CONNECTION_TYPES.items():
             try:
-                await client.connect()
                 result = await client.read_registers(
                     conn_type.serial_start_address,
                     10,


### PR DESCRIPTION
Disable Nagle's algorithm after a reconnection.  The socket is recreated on reconnection, and we weren't re-disabling Nagle's.

Remove ModbusClient.connect. It turns out that pymodbus automatically connects the first time that you try and read/write something anyway. I think that the initial first auto_connect connection was messing up my W610 as well, as I often got a failed read on the first read attempt, and would have to wait for the automatic reconnection to happen. Removing the auto_connect seems to fix this.