### PR TITLE
Add support for invalid address ranges

### DIFF
--- a/custom_components/foxess_modbus/entities/xx1_aux_entity_descriptions.py
+++ b/custom_components/foxess_modbus/entities/xx1_aux_entity_descriptions.py
@@ -620,3 +620,6 @@ H1_AC1: list[EntityFactory] = [
         validate=[Range(0, 100)],
     ),
 ]
+
+# The whole of this range produces 'invalid frame error' if we try and read it
+INVALID_RANGES = [(11096, 39999)]


### PR DESCRIPTION
These are ranges of register addresses which cannot be read. We will never extend a read over one of these ranges, no matter how large max_read is.