### PR TITLE
Rewrite config flow to add adapter selection

### DIFF
--- a/custom_components/foxess_modbus/__init__.py
+++ b/custom_components/foxess_modbus/__init__.py
@@ -75,7 +75,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     # {(modbus_type, host): client}
     clients: dict[tuple[str, str], ModbusClient] = {}
     for inverter_id, inverter in entry.data[INVERTERS].items():
-        options = entry.options.get(INVERTERS, {}).get(inverter_id)
+        # Remember that there might not be any options
+        options = entry.options.get(INVERTERS, {}).get(inverter_id, {})
 
         # Pick the adapter out of the user options if it's there
         adapter_id = options.get(ADAPTER_ID, inverter[ADAPTER_ID])

--- a/custom_components/foxess_modbus/__init__.py
+++ b/custom_components/foxess_modbus/__init__.py
@@ -147,8 +147,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
                             if inverter[INVERTER_CONN] == "LAN":
                                 adapter = ADAPTERS["direct"]
                             else:
-                                # Go for the worst device, which is the W610
-                                adapter = ADAPTERS["usr_w610"]
+                                adapter = ADAPTERS["network_other"]
                         elif modbus_type == SERIAL:
                             adapter = ADAPTERS["serial_other"]
                         inverter[ADAPTER_ID] = adapter.adapter_id

--- a/custom_components/foxess_modbus/__init__.py
+++ b/custom_components/foxess_modbus/__init__.py
@@ -21,6 +21,7 @@ from .const import POLL_RATE
 from .const import SERIAL
 from .const import STARTUP_MESSAGE
 from .const import TCP
+from .const import UDP
 from .inverter_profiles import inverter_connection_type_profile_from_config
 from .modbus_client import ModbusClient
 from .modbus_controller import ModbusController
@@ -66,13 +67,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         inverter_controller.append((inverter, controller))
 
     inverter_controller = []
-    inverters = {k: v for k, v in entry.data.items() if k in (TCP, SERIAL)}
+    inverters = {k: v for k, v in entry.data.items() if k in (TCP, UDP, SERIAL)}
     # create controllers for inverters
     for modbus_type, host_dict in inverters.items():
         for host, name_dict in host_dict.items():
             params = {MODBUS_TYPE: modbus_type}
-            if modbus_type == TCP:
-                params.update({"host": host.split(":")[0], "port": host.split(":")[1]})
+            if modbus_type in [TCP, UDP]:
+                params.update(
+                    {"host": host.split(":")[0], "port": int(host.split(":")[1])}
+                )
             else:
                 params.update({"port": host, "baudrate": 9600})
             client = ModbusClient(hass, params)

--- a/custom_components/foxess_modbus/__init__.py
+++ b/custom_components/foxess_modbus/__init__.py
@@ -75,12 +75,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     # {(modbus_type, host): client}
     clients: dict[tuple[str, str], ModbusClient] = {}
     for inverter_id, inverter in entry.data[INVERTERS].items():
+        options = entry.options.get(INVERTERS, {}).get(inverter_id)
+
+        # Pick the adapter out of the user options if it's there
+        adapter_id = options.get(ADAPTER_ID, inverter[ADAPTER_ID])
+
         # Merge in adapter options. This lets us tweak the adapters later, and those settings are reflected back to users
         # Handle an adapter in need of manual input to complete migration
-        inverter.update(ADAPTERS[inverter[ADAPTER_ID]].inverter_config())
+        # Do this after the lines above, so we can respond to an adapter in the options
+        inverter.update(ADAPTERS[adapter_id].inverter_config())
 
-        # Merge in the options, if any. These can override the adapter options set above
-        options = entry.options.get(INVERTERS, {}).get(inverter_id)
+        # Merge in the user's options, if any. These can override the adapter options set above
         if options:
             inverter.update(options)
 

--- a/custom_components/foxess_modbus/__init__.py
+++ b/custom_components/foxess_modbus/__init__.py
@@ -14,6 +14,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import UNDEFINED
 
 from .const import ADAPTER_ID
+from .const import ADAPTER_WAS_MIGRATED
 from .const import CONFIG_SAVE_TIME
 from .const import DOMAIN
 from .const import FRIENDLY_NAME
@@ -151,6 +152,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
                         elif modbus_type == SERIAL:
                             adapter = ADAPTERS["serial_other"]
                         inverter[ADAPTER_ID] = adapter.adapter_id
+                        inverter[ADAPTER_WAS_MIGRATED] = True
 
                         inverter_id = str(uuid.uuid4())
                         new_data[INVERTERS][inverter_id] = inverter

--- a/custom_components/foxess_modbus/__init__.py
+++ b/custom_components/foxess_modbus/__init__.py
@@ -19,9 +19,9 @@ from .const import CONFIG_SAVE_TIME
 from .const import DOMAIN
 from .const import FRIENDLY_NAME
 from .const import HOST
+from .const import INVERTER_ADAPTER_NEEDS_MANUAL_INPUT
 from .const import INVERTER_CONN
 from .const import INVERTERS
-from .const import INVETER_ADAPTER_NEEDS_MANUAL_INPUT
 from .const import MAX_READ
 from .const import MODBUS_SLAVE
 from .const import MODBUS_TYPE
@@ -110,7 +110,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     # Do this last, so sensors etc can continue to function in the meantime
     for inverter in entry.data[INVERTERS].values():
-        if INVETER_ADAPTER_NEEDS_MANUAL_INPUT in inverter:
+        if INVERTER_ADAPTER_NEEDS_MANUAL_INPUT in inverter:
             raise ConfigEntryAuthFailed(
                 "Configuration needs manual input. Please click 'RECONFIGURE'"
             )
@@ -158,7 +158,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
 
                         # If we need manual input to find the correct adapter type, prompt for this
                         if modbus_type != TCP or inverter[INVERTER_CONN] != "LAN":
-                            inverter[INVETER_ADAPTER_NEEDS_MANUAL_INPUT] = True
+                            inverter[INVERTER_ADAPTER_NEEDS_MANUAL_INPUT] = True
                         inverter_id = str(uuid.uuid4())
                         new_data[INVERTERS][inverter_id] = inverter
                         if inverter_options:

--- a/custom_components/foxess_modbus/__init__.py
+++ b/custom_components/foxess_modbus/__init__.py
@@ -77,9 +77,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     for inverter_id, inverter in entry.data[INVERTERS].items():
         # Merge in adapter options. This lets us tweak the adapters later, and those settings are reflected back to users
         # Handle an adapter in need of manual input to complete migration
-        adapter = ADAPTERS[inverter[ADAPTER_ID]]
-        inverter[MAX_READ] = adapter.max_read
-        inverter[POLL_RATE] = adapter.poll_rate
+        inverter.update(ADAPTERS[inverter[ADAPTER_ID]].inverter_config())
 
         # Merge in the options, if any. These can override the adapter options set above
         options = entry.options.get(INVERTERS, {}).get(inverter_id)
@@ -150,13 +148,13 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
                         # We can infer what the adapter type is, ish
                         if modbus_type == TCP:
                             if inverter[INVERTER_CONN] == "LAN":
-                                adapter = ADAPTERS["lan"]
+                                adapter = ADAPTERS["direct"]
                             else:
                                 # Go for the worst device, which is the W610
                                 adapter = ADAPTERS["usr_w610"]
                         elif modbus_type == SERIAL:
                             adapter = ADAPTERS["serial_other"]
-                        inverter[ADAPTER_ID] = adapter.id
+                        inverter[ADAPTER_ID] = adapter.adapter_id
 
                         # If we need manual input to find the correct adapter type, prompt for this
                         if modbus_type != TCP or inverter[INVERTER_CONN] != "LAN":

--- a/custom_components/foxess_modbus/config_flow.py
+++ b/custom_components/foxess_modbus/config_flow.py
@@ -32,7 +32,6 @@ from .const import CONFIG_SAVE_TIME
 from .const import DOMAIN
 from .const import FRIENDLY_NAME
 from .const import HOST
-from .const import INVERTER_ADAPTER_NEEDS_MANUAL_INPUT
 from .const import INVERTER_BASE
 from .const import INVERTER_CONN
 from .const import INVERTER_MODEL
@@ -129,10 +128,6 @@ class ModbusFlowHandler(FlowHandlerMixin, config_entries.ConfigFlow, domain=DOMA
             InverterAdapterType.NETWORK: self.async_step_tcp_adapter,
         }
 
-        self._config_entry_due_to_migration: config_entries.ConfigEntry | None = None
-        self._config_entry_data_after_migration: dict[str, Any] | None = None
-        self._remaining_inverters_due_to_migration: list[str] | None = None
-
     async def async_step_user(self, _user_input: dict[str, Any] = None):
         """Handle a flow initialized by the user."""
 
@@ -178,15 +173,32 @@ class ModbusFlowHandler(FlowHandlerMixin, config_entries.ConfigFlow, domain=DOMA
     ) -> FlowResult:
         """Let the user select their adapter model"""
 
-        async def complete_callback(adapter: InverterAdapter):
-            self._inverter_data.adapter = adapter
+        async def body(user_input):
+            self._inverter_data.adapter = ADAPTERS[user_input["adapter_model"]]
             return await self._adapter_type_to_step[self._inverter_data.adapter_type]()
 
-        return await self._select_adapter_model_helper(
+        adapters = [
+            x for x in ADAPTERS.values() if x.type == self._inverter_data.adapter_type
+        ]
+
+        schema = vol.Schema(
+            {
+                vol.Required("adapter_model"): selector(
+                    {
+                        "select": {
+                            "options": [x.adapter_id for x in adapters],
+                            "translation_key": "inverter_adapter_models",
+                        }
+                    }
+                )
+            }
+        )
+
+        return await self._with_default_form(
+            body,
+            user_input,
             "select_adapter_model",
-            user_input=user_input,
-            adapter_type=self._inverter_data.adapter_type,
-            complete_callback=complete_callback,
+            schema,
         )
 
     async def async_step_tcp_adapter(
@@ -359,86 +371,6 @@ class ModbusFlowHandler(FlowHandlerMixin, config_entries.ConfigFlow, domain=DOMA
             entry[INVERTERS][str(uuid.uuid4())] = inverter
         entry[CONFIG_SAVE_TIME] = datetime.now()
         return entry
-
-    # Migration support -- handle manual steps needed to complete a migration
-
-    async def async_step_reauth(self, _user_input: dict[str, Any] = None) -> FlowResult:
-        """
-        We use re-authentication as a hack to get users migrating from version 1 who are using
-        a TCP or SERIAL adapter to select their inverter type
-        """
-
-        self._config_entry_due_to_migration = self.hass.config_entries.async_get_entry(
-            self.context["entry_id"]
-        )
-        self._config_entry_data_after_migration = copy.deepcopy(
-            dict(self._config_entry_due_to_migration.data)
-        )
-        self._remaining_inverters_due_to_migration = [
-            k
-            for k, x in self._config_entry_due_to_migration.data[INVERTERS].items()
-            if INVERTER_ADAPTER_NEEDS_MANUAL_INPUT in x
-        ]
-        assert len(self._remaining_inverters_due_to_migration) > 0
-
-        return await self.async_step_select_adapter_model_due_to_migration()
-
-    async def async_step_select_adapter_model_due_to_migration(
-        self, user_input: dict[str, Any] = None
-    ) -> FlowResult:
-        """
-        Called from async_step_reauth when we've done a migration, and need the user to select their adapter.
-        Loops through all inverters in _remaining_inverters_due_to_migration and prompts for the adapter for each.
-        """
-
-        async def step(user_input):
-            inverter_id = self._remaining_inverters_due_to_migration[0]
-            inverter = self._config_entry_data_after_migration[INVERTERS][inverter_id]
-            protocol = inverter[MODBUS_TYPE]  # TCP, UDP, SERIAL
-            if protocol in [TCP, UDP]:
-                assert (
-                    inverter[INVERTER_CONN] == "AUX"
-                )  # We don't expect to be called for LAN
-                adapter_type = InverterAdapterType.NETWORK
-            elif protocol == SERIAL:
-                adapter_type = InverterAdapterType.SERIAL
-            else:
-                assert False
-
-            description_placeholders = {
-                "inverter": self._create_label_for_inverter(inverter),
-            }
-
-            return await self._select_adapter_model_helper(
-                "select_adapter_model_due_to_migration",
-                user_input=user_input,
-                adapter_type=adapter_type,
-                complete_callback=complete_callback,
-                description_placeholders=description_placeholders,
-            )
-
-        async def complete_callback(adapter: InverterAdapter):
-            inverter_id = self._remaining_inverters_due_to_migration.pop(0)
-            inverter = self._config_entry_data_after_migration[INVERTERS][inverter_id]
-            inverter[ADAPTER_ID] = adapter.adapter_id
-            del inverter[INVERTER_ADAPTER_NEEDS_MANUAL_INPUT]
-
-            if len(self._remaining_inverters_due_to_migration) > 0:
-                return await step(None)
-
-            self.hass.config_entries.async_update_entry(
-                self._config_entry_due_to_migration,
-                data=self._config_entry_data_after_migration,
-            )
-            # https://github.com/home-assistant/core/blob/208a44e437e836fdc36292203fd4348f9fa7c331/homeassistant/components/esphome/config_flow.py#L245
-            self.hass.async_create_task(
-                self.hass.config_entries.async_reload(
-                    self._config_entry_due_to_migration.entry_id
-                )
-            )
-            return self.async_abort(reason="reconfigure_successful")
-
-        return await step(user_input)
 
     async def _select_adapter_model_helper(
         self,

--- a/custom_components/foxess_modbus/config_flow.py
+++ b/custom_components/foxess_modbus/config_flow.py
@@ -620,6 +620,8 @@ class ModbusOptionsHandler(FlowHandlerMixin, config_entries.OptionsFlow):
         schema = vol.Schema(schema_parts)
 
         description_placeholders = {
+            # TODO: Will need changing if we let them set the friendly name / host / port
+            "inverter": self._create_label_for_inverter(config),
             "default_poll_rate": current_adapter.poll_rate,
             "default_max_read": current_adapter.max_read,
         }

--- a/custom_components/foxess_modbus/config_flow.py
+++ b/custom_components/foxess_modbus/config_flow.py
@@ -125,7 +125,7 @@ class ModbusFlowHandler(FlowHandlerMixin, config_entries.ConfigFlow, domain=DOMA
         self._all_inverters: list[InverterData] = []
 
         self._adapter_type_to_method = {
-            InverterAdapterType.LAN: self.async_step_tcp_adapter,
+            InverterAdapterType.DIRECT: self.async_step_tcp_adapter,
             InverterAdapterType.SERIAL: self.async_step_serial_adapter,
             InverterAdapterType.NETWORK: self.async_step_tcp_adapter,
         }
@@ -133,7 +133,7 @@ class ModbusFlowHandler(FlowHandlerMixin, config_entries.ConfigFlow, domain=DOMA
         self._config_entry_due_to_migration: config_entries.ConfigEntry | None = None
         self._remaining_inverters_due_to_migration: list[str] | None = None
 
-    async def async_step_user(self, user_input: dict[str, Any] = None):
+    async def async_step_user(self, _user_input: dict[str, Any] = None):
         """Handle a flow initialized by the user."""
 
         return await self.async_step_select_adapter_type()
@@ -246,7 +246,7 @@ class ModbusFlowHandler(FlowHandlerMixin, config_entries.ConfigFlow, domain=DOMA
         async def complete_callback(adapter: InverterAdapter):
             inverter_id = self._remaining_inverters_due_to_migration.pop(0)
             inverter = self._config_entry_due_to_migration.data[INVERTERS][inverter_id]
-            inverter[ADAPTER_ID] = adapter.id
+            inverter[ADAPTER_ID] = adapter.adapter_id
             del inverter[INVETER_ADAPTER_NEEDS_MANUAL_INPUT]
 
             if len(self._remaining_inverters_due_to_migration) > 0:
@@ -284,7 +284,7 @@ class ModbusFlowHandler(FlowHandlerMixin, config_entries.ConfigFlow, domain=DOMA
                 vol.Required("adapter_model"): selector(
                     {
                         "select": {
-                            "options": [x.id for x in adapters],
+                            "options": [x.adapter_id for x in adapters],
                             "translation_key": "inverter_adapter_models",
                         }
                     }
@@ -465,7 +465,7 @@ class ModbusFlowHandler(FlowHandlerMixin, config_entries.ConfigFlow, domain=DOMA
                 FRIENDLY_NAME: inverter.friendly_name,
                 MODBUS_TYPE: inverter.inverter_protocol,
                 HOST: inverter.host,
-                ADAPTER_ID: inverter.adapter.id,
+                ADAPTER_ID: inverter.adapter.adapter_id,
             }
             entry[INVERTERS][str(uuid.uuid4())] = inverter
         entry[CONFIG_SAVE_TIME] = datetime.now()

--- a/custom_components/foxess_modbus/const.py
+++ b/custom_components/foxess_modbus/const.py
@@ -45,6 +45,9 @@ INVERTER = "inverter"
 CONNECTION = "connection"
 MODBUS = "modbus"
 
+# Used as a key in the inverter config to indicate that the adapter was migrated from config version 1
+ADAPTER_WAS_MIGRATED = "adapter_was_migrated"
+
 # Defaults
 DEFAULT_NAME = DOMAIN
 

--- a/custom_components/foxess_modbus/const.py
+++ b/custom_components/foxess_modbus/const.py
@@ -27,8 +27,6 @@ POLL_RATE = "poll_rate"
 MAX_READ = "max_read"
 ADAPTER_ID = "adapter_id"
 
-INVERTER_ADAPTER_NEEDS_MANUAL_INPUT = "inverter_adapter_needs_manual_input"
-
 INVERTER_MODEL = "inverter_model"
 INVERTER_BASE = "inverter_base"
 INVERTER_CONN = "inverter_conn"

--- a/custom_components/foxess_modbus/const.py
+++ b/custom_components/foxess_modbus/const.py
@@ -19,23 +19,18 @@ ATTR_ENTRY_TYPE = "entry_type"
 
 # Modbus Options
 FRIENDLY_NAME = "friendly_name"
-MODBUS_HOST = "modbus_host"
-MODBUS_PORT = "modbus_port"
 MODBUS_SLAVE = "modbus_slave"
 MODBUS_DEVICE = "modbus_device"
 MODBUS_TYPE = "modbus_type"
-MODBUS_SERIAL_HOST = "modbus_serial_host"
 MODBUS_SERIAL_BAUD = "modbus_serial_baud"
 POLL_RATE = "poll_rate"
 MAX_READ = "max_read"
 
-INVERTER_TYPE = "inverter_type"
 INVERTER_MODEL = "inverter_model"
 INVERTER_BASE = "inverter_base"
 INVERTER_CONN = "inverter_conn"
 INVERTERS = "inverters"
 
-ADD_ANOTHER = "add_another"
 CONFIG_SAVE_TIME = "save_time"
 
 TCP = "TCP"

--- a/custom_components/foxess_modbus/const.py
+++ b/custom_components/foxess_modbus/const.py
@@ -39,6 +39,7 @@ ADD_ANOTHER = "add_another"
 CONFIG_SAVE_TIME = "save_time"
 
 TCP = "TCP"
+UDP = "UDP"
 SERIAL = "SERIAL"
 
 CONTROLLER = "controllers"

--- a/custom_components/foxess_modbus/const.py
+++ b/custom_components/foxess_modbus/const.py
@@ -25,6 +25,7 @@ MODBUS_TYPE = "modbus_type"
 MODBUS_SERIAL_BAUD = "modbus_serial_baud"
 POLL_RATE = "poll_rate"
 MAX_READ = "max_read"
+ADAPTER_ID = "adapter_id"
 
 INVERTER_MODEL = "inverter_model"
 INVERTER_BASE = "inverter_base"

--- a/custom_components/foxess_modbus/const.py
+++ b/custom_components/foxess_modbus/const.py
@@ -33,6 +33,7 @@ INVERTERS = "inverters"
 
 CONFIG_SAVE_TIME = "save_time"
 
+HOST = "host"
 TCP = "TCP"
 UDP = "UDP"
 SERIAL = "SERIAL"

--- a/custom_components/foxess_modbus/const.py
+++ b/custom_components/foxess_modbus/const.py
@@ -27,6 +27,8 @@ POLL_RATE = "poll_rate"
 MAX_READ = "max_read"
 ADAPTER_ID = "adapter_id"
 
+INVETER_ADAPTER_NEEDS_MANUAL_INPUT = "needs_migration_manual_input"
+
 INVERTER_MODEL = "inverter_model"
 INVERTER_BASE = "inverter_base"
 INVERTER_CONN = "inverter_conn"

--- a/custom_components/foxess_modbus/const.py
+++ b/custom_components/foxess_modbus/const.py
@@ -27,7 +27,7 @@ POLL_RATE = "poll_rate"
 MAX_READ = "max_read"
 ADAPTER_ID = "adapter_id"
 
-INVETER_ADAPTER_NEEDS_MANUAL_INPUT = "needs_migration_manual_input"
+INVERTER_ADAPTER_NEEDS_MANUAL_INPUT = "inverter_adapter_needs_manual_input"
 
 INVERTER_MODEL = "inverter_model"
 INVERTER_BASE = "inverter_base"
@@ -46,8 +46,6 @@ CONFIG = "config"
 INVERTER = "inverter"
 CONNECTION = "connection"
 MODBUS = "modbus"
-
-ENERGY_DASHBOARD = "energy_dashboard"
 
 # Defaults
 DEFAULT_NAME = DOMAIN

--- a/custom_components/foxess_modbus/inverter_adapters.py
+++ b/custom_components/foxess_modbus/inverter_adapters.py
@@ -12,7 +12,7 @@ class InverterAdapterType(str, Enum):
     """Describes the different means of connecting to an inverter"""
 
     # These values are used as translation keys in the config flow
-    DIRECT = "direct"
+    LAN = "lan"
     SERIAL = "serial"
     NETWORK = "network"
 
@@ -25,6 +25,8 @@ class InverterAdapter:
     type: InverterAdapterType
     connection_type: InverterConnectionType
     setup_link: str
+    poll_rate: int
+    max_read: int
     network_protocols: list[
         str
     ] | None = None  # If type is NETWORK/DIRECT, whether we support TCP and/or UDP
@@ -32,21 +34,29 @@ class InverterAdapter:
 
 
 # The order of elements in this array controls the order they appear in the config flow UI
+# Important: these ids are stored in the config entry, and used to fetch the adapter's settings at start-up
+# We therefore cannot remove or rename any of these!
 ADAPTERS = {
     x.id: x
     for x in [
         InverterAdapter(
-            "direct",
-            InverterAdapterType.DIRECT,
+            "lan",
+            InverterAdapterType.LAN,
             CONNECTION_TYPES["LAN"],
             setup_link="https://github.com/nathanmarlor/foxess_modbus/wiki",
             network_protocols=[TCP],
+            # TODO
+            poll_rate=10,
+            max_read=8,
         ),
         InverterAdapter(
-            "serial",
+            "serial_other",
             InverterAdapterType.SERIAL,
             CONNECTION_TYPES["AUX"],
             setup_link="https://github.com/nathanmarlor/foxess_modbus/wiki",
+            # TODO
+            poll_rate=10,
+            max_read=8,
         ),
         InverterAdapter(
             "usr-w610",
@@ -55,6 +65,8 @@ ADAPTERS = {
             setup_link="https://github.com/nathanmarlor/foxess_modbus/wiki",
             network_protocols=[TCP, UDP],
             recommended_protocol=UDP,
+            poll_rate=10,
+            max_read=8,
         ),
         InverterAdapter(
             "waveshare",
@@ -62,13 +74,19 @@ ADAPTERS = {
             CONNECTION_TYPES["AUX"],
             setup_link="https://github.com/nathanmarlor/foxess_modbus/wiki/Waveshare-RS485-to-ETH-(B)-Setup-Guide",
             network_protocols=[TCP],
+            # TODO
+            poll_rate=10,
+            max_read=50,
         ),
         InverterAdapter(
-            "other_network",
+            "network_other",
             InverterAdapterType.NETWORK,
             CONNECTION_TYPES["AUX"],
             setup_link="https://github.com/nathanmarlor/foxess_modbus/wiki",
             network_protocols=[TCP, UDP],
+            # TODO
+            poll_rate=10,
+            max_read=8,
         ),
     ]
 }

--- a/custom_components/foxess_modbus/inverter_adapters.py
+++ b/custom_components/foxess_modbus/inverter_adapters.py
@@ -153,6 +153,8 @@ ADAPTERS = {
             "network_other",
             "https://github.com/nathanmarlor/foxess_modbus/wiki/Other-Ethernet-Adapter",
             network_protocols=[TCP, UDP],
+            # This might be a W610 and they've been migrated
+            max_read=8,
         ),
     ]
 }

--- a/custom_components/foxess_modbus/inverter_adapters.py
+++ b/custom_components/foxess_modbus/inverter_adapters.py
@@ -3,7 +3,9 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
-from .const import MAX_READ, POLL_RATE, TCP
+from .const import MAX_READ
+from .const import POLL_RATE
+from .const import TCP
 from .const import UDP
 from .inverter_connection_types import CONNECTION_TYPES
 from .inverter_connection_types import InverterConnectionType

--- a/custom_components/foxess_modbus/inverter_adapters.py
+++ b/custom_components/foxess_modbus/inverter_adapters.py
@@ -1,0 +1,44 @@
+"""Contains information on the various adapters to connect to an inverter"""
+from dataclasses import dataclass
+
+from .const import TCP
+from .const import UDP
+from .inverter_connection_types import CONNECTION_TYPES
+from .inverter_connection_types import InverterConnectionType
+
+
+@dataclass
+class InverterAdapter:
+    """Describes an adapter used to connect to an inverter"""
+
+    id: str  # Internal ID, also used as the translation key
+    connection_type: InverterConnectionType
+    setup_link: str
+    protocols: list[str]
+    recommended_protocol: str | None = None
+
+
+ADAPTERS = {
+    x.id: x
+    for x in [
+        InverterAdapter(
+            "direct",
+            CONNECTION_TYPES["LAN"],
+            setup_link="https://github.com/nathanmarlor/foxess_modbus/wiki",
+            protocols=[TCP],
+        ),
+        InverterAdapter(
+            "usr-w610",
+            CONNECTION_TYPES["AUX"],
+            setup_link="https://github.com/nathanmarlor/foxess_modbus/wiki",
+            protocols=[TCP, UDP],
+            recommended_protocol=UDP,
+        ),
+        InverterAdapter(
+            "waveshare",
+            CONNECTION_TYPES["AUX"],
+            setup_link="https://github.com/nathanmarlor/foxess_modbus/wiki/Waveshare-RS485-to-ETH-(B)-Setup-Guide",
+            protocols=[TCP],
+        ),
+    ]
+}

--- a/custom_components/foxess_modbus/inverter_adapters.py
+++ b/custom_components/foxess_modbus/inverter_adapters.py
@@ -1,6 +1,7 @@
 """Contains information on the various adapters to connect to an inverter"""
 from dataclasses import dataclass
 
+from .const import SERIAL
 from .const import TCP
 from .const import UDP
 from .inverter_connection_types import CONNECTION_TYPES
@@ -26,6 +27,12 @@ ADAPTERS = {
             CONNECTION_TYPES["LAN"],
             setup_link="https://github.com/nathanmarlor/foxess_modbus/wiki",
             protocols=[TCP],
+        ),
+        InverterAdapter(
+            "serial",
+            CONNECTION_TYPES["AUX"],
+            setup_link="https://github.com/nathanmarlor/foxess_modbus/wiki",
+            protocols=[SERIAL],
         ),
         InverterAdapter(
             "usr-w610",

--- a/custom_components/foxess_modbus/inverter_adapters.py
+++ b/custom_components/foxess_modbus/inverter_adapters.py
@@ -59,7 +59,7 @@ ADAPTERS = {
             max_read=8,
         ),
         InverterAdapter(
-            "usr-w610",
+            "usr_w610",
             InverterAdapterType.NETWORK,
             CONNECTION_TYPES["AUX"],
             setup_link="https://github.com/nathanmarlor/foxess_modbus/wiki",

--- a/custom_components/foxess_modbus/inverter_adapters.py
+++ b/custom_components/foxess_modbus/inverter_adapters.py
@@ -1,51 +1,74 @@
 """Contains information on the various adapters to connect to an inverter"""
 from dataclasses import dataclass
+from enum import Enum
 
-from .const import SERIAL
 from .const import TCP
 from .const import UDP
 from .inverter_connection_types import CONNECTION_TYPES
 from .inverter_connection_types import InverterConnectionType
 
 
+class InverterAdapterType(str, Enum):
+    """Describes the different means of connecting to an inverter"""
+
+    # These values are used as translation keys in the config flow
+    DIRECT = "direct"
+    SERIAL = "serial"
+    NETWORK = "network"
+
+
 @dataclass
 class InverterAdapter:
     """Describes an adapter used to connect to an inverter"""
 
-    id: str  # Internal ID, also used as the translation key
+    id: str  # Internal ID, also used as the translation key in the config flow
+    type: InverterAdapterType
     connection_type: InverterConnectionType
     setup_link: str
-    protocols: list[str]
+    network_protocols: list[
+        str
+    ] | None = None  # If type is NETWORK/DIRECT, whether we support TCP and/or UDP
     recommended_protocol: str | None = None
 
 
+# The order of elements in this array controls the order they appear in the config flow UI
 ADAPTERS = {
     x.id: x
     for x in [
         InverterAdapter(
             "direct",
+            InverterAdapterType.DIRECT,
             CONNECTION_TYPES["LAN"],
             setup_link="https://github.com/nathanmarlor/foxess_modbus/wiki",
-            protocols=[TCP],
+            network_protocols=[TCP],
         ),
         InverterAdapter(
             "serial",
+            InverterAdapterType.SERIAL,
             CONNECTION_TYPES["AUX"],
             setup_link="https://github.com/nathanmarlor/foxess_modbus/wiki",
-            protocols=[SERIAL],
         ),
         InverterAdapter(
             "usr-w610",
+            InverterAdapterType.NETWORK,
             CONNECTION_TYPES["AUX"],
             setup_link="https://github.com/nathanmarlor/foxess_modbus/wiki",
-            protocols=[TCP, UDP],
+            network_protocols=[TCP, UDP],
             recommended_protocol=UDP,
         ),
         InverterAdapter(
             "waveshare",
+            InverterAdapterType.NETWORK,
             CONNECTION_TYPES["AUX"],
             setup_link="https://github.com/nathanmarlor/foxess_modbus/wiki/Waveshare-RS485-to-ETH-(B)-Setup-Guide",
-            protocols=[TCP],
+            network_protocols=[TCP],
+        ),
+        InverterAdapter(
+            "other_network",
+            InverterAdapterType.NETWORK,
+            CONNECTION_TYPES["AUX"],
+            setup_link="https://github.com/nathanmarlor/foxess_modbus/wiki",
+            network_protocols=[TCP, UDP],
         ),
     ]
 }

--- a/custom_components/foxess_modbus/inverter_adapters.py
+++ b/custom_components/foxess_modbus/inverter_adapters.py
@@ -19,7 +19,7 @@ class InverterAdapterType(str, Enum):
 
 
 _DEFAULT_POLL_RATE = 10
-_DEFAULT_MAX_READ = 50
+_DEFAULT_MAX_READ = 100  # Perhaps a bit optimistic?
 
 
 @dataclass
@@ -137,7 +137,6 @@ ADAPTERS = {
             "https://github.com/nathanmarlor/foxess_modbus/wiki/USR-W610",
             network_protocols=[TCP, UDP],
             recommended_protocol=UDP,
-            poll_rate=10,
             max_read=8,
         ),
         InverterAdapter.network(

--- a/custom_components/foxess_modbus/inverter_adapters.py
+++ b/custom_components/foxess_modbus/inverter_adapters.py
@@ -21,7 +21,7 @@ class InverterAdapterType(str, Enum):
 
 
 _DEFAULT_POLL_RATE = 10
-_DEFAULT_MAX_READ = 100  # Perhaps a bit optimistic?
+_DEFAULT_MAX_READ = 20  # Be safe by default
 
 
 @dataclass
@@ -119,6 +119,7 @@ ADAPTERS = {
         InverterAdapter.serial(
             "dsd_tech_sh_u10",
             "https://github.com/nathanmarlor/foxess_modbus/wiki/DSD-TECH-SH-U10",
+            max_read=100,
         ),
         InverterAdapter.serial(
             "runcci_yun_usb_to_rs485_converter",
@@ -133,6 +134,7 @@ ADAPTERS = {
             "usr_tcp232_410s",
             "https://github.com/nathanmarlor/foxess_modbus/wiki/USR-TCP232-410s",
             network_protocols=[TCP, UDP],
+            max_read=100,
         ),
         InverterAdapter.network(
             "usr_w610",
@@ -145,6 +147,7 @@ ADAPTERS = {
             "waveshare_rs485_to_eth_b",
             "https://github.com/nathanmarlor/foxess_modbus/wiki/Waveshare-RS485-to-ETH-%28B%29",
             network_protocols=[TCP, UDP],
+            max_read=100,
         ),
         InverterAdapter.network(
             "network_other",

--- a/custom_components/foxess_modbus/modbus_client.py
+++ b/custom_components/foxess_modbus/modbus_client.py
@@ -5,11 +5,13 @@ from typing import Any
 
 from pymodbus.client import ModbusSerialClient
 from pymodbus.client import ModbusTcpClient
+from pymodbus.client import ModbusUdpClient
 from pymodbus.exceptions import ModbusIOException
 
 from .const import MODBUS_TYPE
 from .const import SERIAL
 from .const import TCP
+from .const import UDP
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,6 +44,7 @@ class ModbusClient:
         self._class = {
             SERIAL: ModbusSerialClient,
             TCP: CustomModbusTcpClient,
+            UDP: ModbusUdpClient,
         }
         self._poll_delay = 30 / 1000 if self._config_type == SERIAL else 0
 

--- a/custom_components/foxess_modbus/translations/en.json
+++ b/custom_components/foxess_modbus/translations/en.json
@@ -54,25 +54,6 @@
           "select_adapter": "Add another Inverter"
         }
       },
-      "tcp": {
-        "description": "Please enter your Modbus IP and Port.\nSet friendly name if you have more than one inverter, otherwise leave blank.",
-        "data": {
-          "friendly_name": "Friendly Name",
-          "modbus_host": "Modbus Host",
-          "modbus_port": "Modbus Port",
-          "modbus_slave": "Modbus Slave",
-          "add_another": "Add another device"
-        }
-      },
-      "serial": {
-        "description": "Please enter your serial or usb device id. \nSet friendly name if you have more than one inverter, otherwise leave blank.",
-        "data": {
-          "friendly_name": "Friendly Name",
-          "modbus_serial_host": "Modbus Serial Host",
-          "modbus_slave": "Modbus Slave",
-          "add_another": "Add another device"
-        }
-      },
       "energy": {
         "description": "Warning: this will overwrite any existing settings. \nWe recommend checking the configuration at (https://your-ha.com/config/energy)",
         "data": {

--- a/custom_components/foxess_modbus/translations/en.json
+++ b/custom_components/foxess_modbus/translations/en.json
@@ -19,6 +19,12 @@
           "adapter_model": null
         }
       },
+      "select_adapter_model_due_to_migration": {
+        "description": "Choose the adapter model for the inverter \"{inverter}\". This lets us use settings tailored to your adapter.",
+        "data": {
+          "adapter_model": null
+        }
+      },
       "tcp_adapter": {
         "description": "Set up your adapter by following the instructions at {setup_link}.",
         "data": {
@@ -75,7 +81,8 @@
       "invalid_friendly_name": "Friendly name must contain only lower-case letters, numbers and underscores"
     },
     "abort": {
-      "single_instance_allowed": "Only a single instance is allowed."
+      "single_instance_allowed": "Only a single instance is allowed.",
+      "reconfigure_successful": "Successful"
     }
   },
   "options": {
@@ -109,7 +116,7 @@
     },
     "inverter_adapter_models": {
       "options": {
-        "usr-w610": "USR-W610",
+        "usr_w610": "USR-W610",
         "waveshare": "Waveshare Modbus RTU Relay",
         "network_other": "Other"
       }

--- a/custom_components/foxess_modbus/translations/en.json
+++ b/custom_components/foxess_modbus/translations/en.json
@@ -8,7 +8,7 @@
         }
       },
       "select_adapter_model": {
-        "description": "Choose your adapter model. This lets us use settings tailored to your adapter.",
+        "description": "Choose your adapter model. This lets us use settings tailored to your adapter. If you don't see your model, choose \"Other\" and let us know: https://github.com/nathanmarlor/foxess_modbus/discussions/new.",
         "data": {
           "adapter_id": ""
         }

--- a/custom_components/foxess_modbus/translations/en.json
+++ b/custom_components/foxess_modbus/translations/en.json
@@ -7,6 +7,26 @@
           "modbus_type": "Modbus Type"
         }
       },
+      "select_adapter": {
+        "description": "Choose how you connect to your inverter.",
+        "data": {
+          "adapter": null
+        }
+      },
+      "tcp_adapter": {
+        "description": "Set up your adapter by following the instructions at {setup_link}.",
+        "data": {
+          "protocol": "Protocol",
+          "protocol_with_recommendation": "Protocol",
+          "direct_connection_host": "Inverter hostname / IP address",
+          "adapter_host": "Modbus adapter hostname / IP address",
+          "adapter_port": "Modbus adapter port",
+          "adapter_slave": "Modbus adapter slave"
+        },
+        "data_description": {
+          "protocol_with_recommendation": "We recommend using {recommended_protocol} with this adapter"
+        }
+      },
       "tcp": {
         "description": "Please enter your Modbus IP and Port.\nSet friendly name if you have more than one inverter, otherwise leave blank.",
         "data": {
@@ -51,6 +71,15 @@
           "poll_rate": "Poll rate",
           "max_read": "Max read"
         }
+      }
+    }
+  },
+  "selector": {
+    "inverter_adapters": {
+      "options": {
+        "direct": "Direct LAN Connection",
+        "usr-w610": "USR-W610",
+        "waveshare": "Waveshare Modbus RTU Relay"
       }
     }
   }

--- a/custom_components/foxess_modbus/translations/en.json
+++ b/custom_components/foxess_modbus/translations/en.json
@@ -10,7 +10,7 @@
       "select_adapter_model": {
         "description": "Choose your adapter model. This lets us use settings tailored to your adapter.",
         "data": {
-          "adapter_model": ""
+          "adapter_id": ""
         }
       },
       "tcp_adapter": {
@@ -83,6 +83,7 @@
       "inverter_options": {
         "description": "Warning: only change these if you know what you are doing. Enable debug logging and watch it to see whether your new settings cause any problems.",
         "data": {
+          "adapter_id": "Adapter",
           "poll_rate": "Poll rate",
           "max_read": "Max read"
         },

--- a/custom_components/foxess_modbus/translations/en.json
+++ b/custom_components/foxess_modbus/translations/en.json
@@ -36,7 +36,7 @@
           "modbus_slave": "Inverter slave ID"
         },
         "data_description": {
-          "protocol_with_recommendation": "We recommend using {recommended_protocol} with this adapter",
+          "protocol_with_recommendation": "We recommend using {recommended_protocol} with this adapter, see the link above",
           "modbus_slave": "This can be set from Settings -> Communication in the inverter menu"
         }
       },
@@ -100,8 +100,8 @@
           "max_read": "Max read"
         },
         "data_description": {
-          "poll_rate": "The default for your adapter type is {default_poll_rate}. Leave empty to restore default",
-          "max_read": "The default for your adapter type is {default_max_read}. Leave empty to restore default"
+          "poll_rate": "The default for your adapter type is {default_poll_rate}. Leave empty to use the default",
+          "max_read": "The default for your adapter type is {default_max_read}. Leave empty to use the default"
         }
       }
     }
@@ -109,15 +109,19 @@
   "selector": {
     "inverter_adapter_types": {
       "options": {
-        "lan": "Direct LAN Connection",
+        "direct": "Direct LAN Connection",
         "serial": "USB to Modbus Adapter",
         "network": "Ethernet to Modbus Adapter"
       }
     },
     "inverter_adapter_models": {
       "options": {
+        "dsd_tech_sh_u10": "DSD TECH SH-U10",
+        "runcci_yun_usb_to_rs485_converter": "RUNCCI-YUN USB to RS485 Converter",
+        "serial_other": "Other",
+        "usr_tcp232_410s": "USR-TCP-410s",
         "usr_w610": "USR-W610",
-        "waveshare": "Waveshare Modbus RTU Relay",
+        "waveshare_rs485_to_eth_b": "Waveshare Modbus RTU Relay",
         "network_other": "Other"
       }
     }

--- a/custom_components/foxess_modbus/translations/en.json
+++ b/custom_components/foxess_modbus/translations/en.json
@@ -21,10 +21,37 @@
           "direct_connection_host": "Inverter hostname / IP address",
           "adapter_host": "Modbus adapter hostname / IP address",
           "adapter_port": "Modbus adapter port",
-          "adapter_slave": "Modbus adapter slave"
+          "inverter_slave": "Inverter slave ID"
         },
         "data_description": {
-          "protocol_with_recommendation": "We recommend using {recommended_protocol} with this adapter"
+          "protocol_with_recommendation": "We recommend using {recommended_protocol} with this adapter",
+          "inverter_slave": "This can be set from Settings -> Communication in the inverter menu"
+        }
+      },
+      "serial_adapter": {
+        "description": "Set up your adapter by following the instructions at {setup_link}.",
+        "data": {
+          "serial_device": "USB serial device",
+          "inverter_slave": "Inverter slave ID"
+        },
+        "data_description": {
+          "inverter_slave": "This can be set from Settings -> Communication in the inverter menu"
+        }
+      },
+      "friendly_name": {
+        "description": "If you have more than one inverter, give them each a name to tell them apart",
+        "data": {
+          "friendly_name": "Friendly Name"
+        },
+        "data_description": {
+          "friendly_name": "This is added as a prefix to all of the inverter's entity IDs"
+        }
+      },
+      "add_another_inverter": {
+        "description": "Set-up complete. Do you want to add another inverter?",
+        "menu_options": {
+          "energy": "I'm Done",
+          "select_adapter": "Add another Inverter"
         }
       },
       "tcp": {
@@ -78,6 +105,7 @@
     "inverter_adapters": {
       "options": {
         "direct": "Direct LAN Connection",
+        "serial": "USB to Modbus Adapter",
         "usr-w610": "USR-W610",
         "waveshare": "Waveshare Modbus RTU Relay"
       }

--- a/custom_components/foxess_modbus/translations/en.json
+++ b/custom_components/foxess_modbus/translations/en.json
@@ -7,10 +7,16 @@
           "modbus_type": "Modbus Type"
         }
       },
-      "select_adapter": {
-        "description": "Choose how you connect to your inverter.",
+      "select_adapter_type": {
+        "description": "How do you connect to your inverter?",
         "data": {
-          "adapter": null
+          "adapter_type": null
+        }
+      },
+      "select_adapter_model": {
+        "description": "Choose your adapter model. This lets us use settings tailored to your adapter.",
+        "data": {
+          "adapter_model": null
         }
       },
       "tcp_adapter": {
@@ -84,12 +90,16 @@
     }
   },
   "selector": {
-    "inverter_adapters": {
+    "inverter_adapter_types": {
+      "direct": "Direct LAN Connection",
+      "serial": "USB to Modbus Adapter",
+      "network": "Ethernet to Modbus Adapter"
+    },
+    "inverter_adapter_models": {
       "options": {
-        "direct": "Direct LAN Connection",
-        "serial": "USB to Modbus Adapter",
         "usr-w610": "USR-W610",
-        "waveshare": "Waveshare Modbus RTU Relay"
+        "waveshare": "Waveshare Modbus RTU Relay",
+        "other_network": "Other"
       }
     }
   }

--- a/custom_components/foxess_modbus/translations/en.json
+++ b/custom_components/foxess_modbus/translations/en.json
@@ -24,7 +24,7 @@
         "data": {
           "protocol": "Protocol",
           "protocol_with_recommendation": "Protocol",
-          "direct_connection_host": "Inverter hostname / IP address",
+          "lan_connection_host": "Inverter hostname / IP address",
           "adapter_host": "Modbus adapter hostname / IP address",
           "adapter_port": "Modbus adapter port",
           "modbus_slave": "Inverter slave ID"
@@ -80,11 +80,21 @@
   },
   "options": {
     "step": {
-      "init": {
-        "description": "Configure the poll rate and max read values\nRecommended: AUX: 10s / 8 max & LAN: 5s / 50 max",
+      "select_inverter": {
+        "description": "Select inverter to configure",
+        "data": {
+          "inverter": null
+        }
+      },
+      "inverter_options": {
+        "description": "Warning: only change these if you know what you are doing. Enable debug logging and watch it to see whether your new settings cause any problems",
         "data": {
           "poll_rate": "Poll rate",
           "max_read": "Max read"
+        },
+        "data_description": {
+          "poll_rate": "The default for your adapter type is {default_poll_rate}. Leave empty to restore default",
+          "max_read": "The default for your adapter type is {default_max_read}. Leave empty to restore default"
         }
       }
     }
@@ -92,7 +102,7 @@
   "selector": {
     "inverter_adapter_types": {
       "options": {
-        "direct": "Direct LAN Connection",
+        "lan": "Direct LAN Connection",
         "serial": "USB to Modbus Adapter",
         "network": "Ethernet to Modbus Adapter"
       }
@@ -101,7 +111,7 @@
       "options": {
         "usr-w610": "USR-W610",
         "waveshare": "Waveshare Modbus RTU Relay",
-        "other_network": "Other"
+        "network_other": "Other"
       }
     }
   }

--- a/custom_components/foxess_modbus/translations/en.json
+++ b/custom_components/foxess_modbus/translations/en.json
@@ -1,28 +1,22 @@
 {
   "config": {
     "step": {
-      "user": {
-        "description": "Please choose how your modbus adapter is connected",
-        "data": {
-          "modbus_type": "Modbus Type"
-        }
-      },
       "select_adapter_type": {
         "description": "How do you connect to your inverter?",
         "data": {
-          "adapter_type": null
+          "adapter_type": ""
         }
       },
       "select_adapter_model": {
         "description": "Choose your adapter model. This lets us use settings tailored to your adapter.",
         "data": {
-          "adapter_model": null
+          "adapter_model": ""
         }
       },
       "select_adapter_model_due_to_migration": {
         "description": "Choose the adapter model for the inverter \"{inverter}\". This lets us use settings tailored to your adapter.",
         "data": {
-          "adapter_model": null
+          "adapter_model": ""
         }
       },
       "tcp_adapter": {
@@ -51,7 +45,7 @@
         }
       },
       "friendly_name": {
-        "description": "If you have more than one inverter, give them each a name to tell them apart",
+        "description": "If you have more than one inverter, give them each a name to tell them apart.",
         "data": {
           "friendly_name": "Friendly Name"
         },
@@ -62,12 +56,12 @@
       "add_another_inverter": {
         "description": "Set-up complete. Do you want to add another inverter?",
         "menu_options": {
-          "energy": "I'm Done",
-          "select_adapter": "Add another Inverter"
+          "energy": "I'm done",
+          "select_adapter_type": "Add another inverter"
         }
       },
       "energy": {
-        "description": "Warning: this will overwrite any existing settings. \nWe recommend checking the configuration at (https://your-ha.com/config/energy)",
+        "description": "Warning: this will overwrite any existing settings.\nWe recommend checking the configuration at (https://your-ha.com/config/energy).",
         "data": {
           "energy_dashboard": "Automatically configure the Energy Dashboard"
         }
@@ -81,20 +75,19 @@
       "invalid_friendly_name": "Friendly name must contain only lower-case letters, numbers and underscores"
     },
     "abort": {
-      "single_instance_allowed": "Only a single instance is allowed.",
-      "reconfigure_successful": "Successful"
+      "reconfigure_successful": "Successful. We can now use settings specific to your adapter."
     }
   },
   "options": {
     "step": {
       "select_inverter": {
-        "description": "Select inverter to configure",
+        "description": "Select inverter to configure.",
         "data": {
-          "inverter": null
+          "inverter": ""
         }
       },
       "inverter_options": {
-        "description": "Warning: only change these if you know what you are doing. Enable debug logging and watch it to see whether your new settings cause any problems",
+        "description": "Warning: only change these if you know what you are doing. Enable debug logging and watch it to see whether your new settings cause any problems.",
         "data": {
           "poll_rate": "Poll rate",
           "max_read": "Max read"

--- a/custom_components/foxess_modbus/translations/en.json
+++ b/custom_components/foxess_modbus/translations/en.json
@@ -21,21 +21,21 @@
           "direct_connection_host": "Inverter hostname / IP address",
           "adapter_host": "Modbus adapter hostname / IP address",
           "adapter_port": "Modbus adapter port",
-          "inverter_slave": "Inverter slave ID"
+          "modbus_slave": "Inverter slave ID"
         },
         "data_description": {
           "protocol_with_recommendation": "We recommend using {recommended_protocol} with this adapter",
-          "inverter_slave": "This can be set from Settings -> Communication in the inverter menu"
+          "modbus_slave": "This can be set from Settings -> Communication in the inverter menu"
         }
       },
       "serial_adapter": {
         "description": "Set up your adapter by following the instructions at {setup_link}.",
         "data": {
           "serial_device": "USB serial device",
-          "inverter_slave": "Inverter slave ID"
+          "modbus_slave": "Inverter slave ID"
         },
         "data_description": {
-          "inverter_slave": "This can be set from Settings -> Communication in the inverter menu"
+          "modbus_slave": "This can be set from Settings -> Communication in the inverter menu"
         }
       },
       "friendly_name": {
@@ -81,7 +81,8 @@
       }
     },
     "error": {
-      "modbus_duplicate": "Please enter a unique host/friendly name",
+      "duplicate_connection_details": "You have already set up an inverter with this address",
+      "duplicate_friendly_name": "Please enter a unique friendly name",
       "modbus_error": "Error - please check connection details",
       "modbus_model_not_supported": "Error - model is not supported",
       "invalid_friendly_name": "Friendly name must contain only lower-case letters, numbers and underscores"

--- a/custom_components/foxess_modbus/translations/en.json
+++ b/custom_components/foxess_modbus/translations/en.json
@@ -81,7 +81,7 @@
         }
       },
       "inverter_options": {
-        "description": "Warning: only change these if you know what you are doing. Enable debug logging and watch it to see whether your new settings cause any problems.",
+        "description": "Options for \"{inverter}\".",
         "data": {
           "adapter_id": "Adapter",
           "poll_rate": "Poll rate",
@@ -89,7 +89,7 @@
         },
         "data_description": {
           "poll_rate": "The default for your adapter type is {default_poll_rate}. Leave empty to use the default",
-          "max_read": "The default for your adapter type is {default_max_read}. Leave empty to use the default"
+          "max_read": "The default for your adapter type is {default_max_read}. Leave empty to use the default. Warning: Look at the debug log for problems if you increase this!"
         }
       }
     }

--- a/custom_components/foxess_modbus/translations/en.json
+++ b/custom_components/foxess_modbus/translations/en.json
@@ -91,9 +91,11 @@
   },
   "selector": {
     "inverter_adapter_types": {
-      "direct": "Direct LAN Connection",
-      "serial": "USB to Modbus Adapter",
-      "network": "Ethernet to Modbus Adapter"
+      "options": {
+        "direct": "Direct LAN Connection",
+        "serial": "USB to Modbus Adapter",
+        "network": "Ethernet to Modbus Adapter"
+      }
     },
     "inverter_adapter_models": {
       "options": {

--- a/custom_components/foxess_modbus/translations/en.json
+++ b/custom_components/foxess_modbus/translations/en.json
@@ -13,12 +13,6 @@
           "adapter_model": ""
         }
       },
-      "select_adapter_model_due_to_migration": {
-        "description": "Choose the adapter model for the inverter \"{inverter}\". This lets us use settings tailored to your adapter.",
-        "data": {
-          "adapter_model": ""
-        }
-      },
       "tcp_adapter": {
         "description": "Set up your adapter by following the instructions at {setup_link}.",
         "data": {


### PR DESCRIPTION
I'm submitting this at draft for now, to get some initial feedback. It's based on #138, so I'll rebase it when that gets in. I wouldn't recommend getting this in the next release either, let's give it a bit of time in beta.

At a high level, this rewrites the config flow and configuration format to support letting the user select their exact adapter.

The first step in the config flow is:

<img src="https://user-images.githubusercontent.com/568104/232328108-9fd1a46f-7730-4e78-91ff-ffd637d05964.png" width="300px"/>

"Direct LAN connection" takes you straight through to the IP/port selection (we'll see that in a minute). The other two options give you a list of suitable adapters:

<img src="https://user-images.githubusercontent.com/568104/232328154-40021045-7434-4a66-b1b0-0ad38d54891b.png" width="300px"/>

and:

<img src="https://user-images.githubusercontent.com/568104/232328174-4982f34b-c3eb-4e8b-8f8d-82c1658d4da4.png" width="300px"/>

There are several variations of the page you see after selecting one. First, a serial one:

<img src="https://user-images.githubusercontent.com/568104/232328226-c4309249-e0ac-49da-80d9-4c6cf58d5b36.png" width="300px"/>

That's fairly unchanged, except that we've moved the friendly name setting to the next page (more on that later), and the option to add another inverter is now slightly later in the flow as well.

Note the link to the wiki with instructions on how to set it up too!

The ethernet one comes in several variations. If it's a direct connection, we just prompt for hostname and slave:

<img src="https://user-images.githubusercontent.com/568104/232328322-46be696b-a9c3-4b3f-b893-336333212764.png" width="300px"/>

For the other ones, if it supports both TCP and UDP (yes, we now support UDP!), we give them a selector at the top:

<img src="https://user-images.githubusercontent.com/568104/232328423-21d64dbc-5224-4f75-859f-2ac973bfa6d0.png" width="300px"/>

And if we want to nudge them in a particular direction, there's a bit of text under the protocol selector:

<img src="https://user-images.githubusercontent.com/568104/232328457-9d436027-02e3-4ea2-ad1b-531d3c0b5a78.png" width="300px"/>

Whichever route you take, the next option is for the friendly name:

<img src="https://user-images.githubusercontent.com/568104/232328491-58417cf3-e719-4fd3-8b92-1bf1af8dd5bf.png" width="300px"/>

I moved this onto its own page partly to reduce the duplicate validation logic, partly so that the host and friendly name can be validated separately (one concern at a time), and partly to give room for extra field such as name prefix/suffix in the future. It also gives us a chance to properly explain what this field is talking about.

After that we have the option to add another inverter, pulled out to make it a bit more obvious:

<img src="https://user-images.githubusercontent.com/568104/232328592-8fa8a9aa-3556-4b3d-a138-78b437301bd0.png" width="300px"/>

And finally the energy dashboard:

<img src="https://user-images.githubusercontent.com/568104/232328903-dbc4c0af-847c-447c-a558-58a2b8575de9.png" width="300px"/>

------------

The configure menu has also changed a bit. Settings are now per-inverter: if you have multiple inverters configured, you first get to choose which one:

<img src="https://user-images.githubusercontent.com/568104/232328979-6ad85e3b-2406-43ff-9bd8-a778142b3bbe.png" width="300px"/>

If you only have a single inverter, you don't get this option -- you just go straight to the next page:

<img src="https://user-images.githubusercontent.com/568104/232329027-2c44f1ce-1dff-45da-a818-1d51cf2c9651.png" width="300px"/>

This is pretty much the same, except that you can leave the fields blank to use the defaults for that adapter.

--------

~~If you have an inverter configured when you upgrade, we handle migrations. If you're using a serial or ethernet adapter, you'll get prompted to reconfigure:~~

<img src="https://user-images.githubusercontent.com/568104/232329776-020d0a83-2786-41de-b046-d7c1a6e6e39c.png" width="300px"/>

~~Things will keep working in the meantime: we assume they're using the W610 until they tell us otherwise.~~ 

~~They then get prompted to select the adapter for each:~~

<img src="https://user-images.githubusercontent.com/568104/232329810-1c9757fd-5620-4f1d-8edb-4244bda91278.png" width="300px"/>

(Removed due to probably being too confusing)

----------------

max_read and poll_rate are now part of the adapter configuration, and they aren't stored in the `ConfigEntry.data`. This means that we can change them in future if we realise that a particular adapter needs special handling in some way (that's why I'm trying to gather a list of all adapters now, even if the settings for most are the same -- it lets us change the settings for users with that adapter later). 

Configuration options (`ConfigEntry.options)` are then overlayed on top, so they override whatever the defaults for that adapter are. We no longer duplicate `ConfigEntry.data` into `ConfigEntry.options` -- this lets us migrate them more easily in the future, and it lets the user revert individual settings back to the adapter defaults.

(Configuration options are also migrated currently, with the user's max_read and poll_rate being applied to all of their configured inverters).

I've tweaked the configuration format to be easier to work with: it used to be quite nested, which made it hard to do things like change the settings for an individual inverter from the config flow. It's now more flat -- just a dict of inverter id -> settings dict. On that note I've given each inverter a GUID ID. This is used to correlate settings across `ConfigEntry.data` and `ConfigEntry.options`, and it can stay the same even if we let the user change the friendly name in the future.