### PR TITLE
Fix energy dashboard

### DIFF
--- a/custom_components/foxess_modbus/__init__.py
+++ b/custom_components/foxess_modbus/__init__.py
@@ -5,9 +5,11 @@ For more details about this integration, please refer to
 https://github.com/nathanmarlor/foxess_modbus
 """
 import asyncio
+import copy
 import logging
 import uuid
 
+from homeassistant.components.energy import data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import Config
 from homeassistant.core import HomeAssistant
@@ -120,6 +122,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     _LOGGER.debug("Migrating from version %s", config_entry.version)
 
     if config_entry.version == 1:
+        # Introduce adapter selection
         new_data = {
             INVERTERS: {},
             CONFIG_SAVE_TIME: config_entry.data[CONFIG_SAVE_TIME],
@@ -159,10 +162,29 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
                         if inverter_options:
                             options[INVERTERS][inverter_id] = inverter_options
 
-        config_entry.version = 2
         hass.config_entries.async_update_entry(
             config_entry, data=new_data, options=options
         )
+        config_entry.version = 2
+
+    if config_entry.version == 2:
+        # Fix a badly-set-up energy dashboard
+        energy_manager = await data.async_get_manager(hass)
+        energy_data = copy.deepcopy(energy_manager.data)
+        for energy_source in energy_data.get("energy_sources", []):
+            if energy_source["type"] == "solar":
+                energy_source.setdefault("config_entry_solar_forecast", None)
+            elif energy_source["type"] == "grid":
+                for flow_from in energy_source.get("flow_from", []):
+                    flow_from.setdefault("stat_cost", None)
+                    flow_from.setdefault("entity_energy_price", None)
+                    flow_from.setdefault("number_energy_price", None)
+                for flow_to in energy_source.get("flow_to", []):
+                    flow_to.setdefault("stat_compensation", None)
+                    flow_to.setdefault("entity_energy_price", None)
+                    flow_to.setdefault("number_energy_price", None)
+        await energy_manager.async_update(energy_data)
+        config_entry.version = 3
 
     _LOGGER.info("Migration to version %s successful", config_entry.version)
     return True

--- a/custom_components/foxess_modbus/config_flow.py
+++ b/custom_components/foxess_modbus/config_flow.py
@@ -114,7 +114,7 @@ class FlowHandlerMixin:
 class ModbusFlowHandler(FlowHandlerMixin, config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow for foxess_modbus."""
 
-    VERSION = 2
+    VERSION = 3
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
     def __init__(self) -> None:
@@ -467,10 +467,14 @@ class ModbusFlowHandler(FlowHandlerMixin, config_entries.ConfigFlow, domain=DOMA
             energy_prefs["energy_sources"].extend(
                 [
                     SolarSourceType(
-                        type="solar", stat_energy_from=f"{name_prefix}pv1_energy_total"
+                        type="solar",
+                        stat_energy_from=f"{name_prefix}pv1_energy_total",
+                        config_entry_solar_forecast=None,
                     ),
                     SolarSourceType(
-                        type="solar", stat_energy_from=f"{name_prefix}pv2_energy_total"
+                        type="solar",
+                        stat_energy_from=f"{name_prefix}pv2_energy_total",
+                        config_entry_solar_forecast=None,
                     ),
                     BatterySourceType(
                         type="battery",
@@ -481,18 +485,24 @@ class ModbusFlowHandler(FlowHandlerMixin, config_entries.ConfigFlow, domain=DOMA
             )
 
         grid_source = GridSourceType(
-            type="grid", flow_from=[], flow_to=[], cost_adjustment_day=0
+            type="grid", flow_from=[], flow_to=[], cost_adjustment_day=0.0
         )
         for name in friendly_names:
             name_prefix = _prefix_name(name)
             grid_source["flow_from"].append(
                 FlowFromGridSourceType(
-                    stat_energy_from=f"{name_prefix}grid_consumption_energy_total"
+                    stat_energy_from=f"{name_prefix}grid_consumption_energy_total",
+                    stat_cost=None,
+                    entity_energy_price=None,
+                    number_energy_price=None,
                 )
             )
             grid_source["flow_to"].append(
                 FlowToGridSourceType(
-                    stat_energy_to=f"{name_prefix}feed_in_energy_total"
+                    stat_energy_to=f"{name_prefix}feed_in_energy_total",
+                    stat_compensation=None,
+                    entity_energy_price=None,
+                    number_energy_price=None,
                 )
             )
         energy_prefs["energy_sources"].append(grid_source)


### PR DESCRIPTION
It turns out that the energy dashboard wants us to specify all keys, even if their value is None. However, that's not what TypedDict does by default.

Fix the setup in the config flow, and add a migration to fix existing breakages.

Fixes: #172