### PR TITLE
Bump min HA version to 2023.3.0

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "FoxESS - Modbus",
   "hacs": "1.20.0",
-  "homeassistant": "2022.2.0",
+  "homeassistant": "2023.3.0",
   "render_readme": true
 }


### PR DESCRIPTION
- The config flow depends on select's translation_key, which came in 2023.2.0
- The config flow uses vol.Any(None, ...) which was introduced in 2023.3.0