### PR TITLE
Let friendly names have spaces in again

### DIFF
--- a/custom_components/foxess_modbus/__init__.py
+++ b/custom_components/foxess_modbus/__init__.py
@@ -19,6 +19,7 @@ from .const import ADAPTER_ID
 from .const import ADAPTER_WAS_MIGRATED
 from .const import CONFIG_SAVE_TIME
 from .const import DOMAIN
+from .const import ENTITY_ID_PREFIX
 from .const import FRIENDLY_NAME
 from .const import HOST
 from .const import INVERTER_CONN
@@ -186,6 +187,12 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
                         flow_to.setdefault("number_energy_price", None)
             await energy_manager.async_update(energy_data)
         config_entry.version = 3
+
+    if config_entry.version == 3:
+        # Add entity ID prefix
+        for inverter in config_entry.data.get(INVERTERS, {}).values():
+            inverter[ENTITY_ID_PREFIX] = inverter[FRIENDLY_NAME]
+        config_entry.version = 4
 
     _LOGGER.info("Migration to version %s successful", config_entry.version)
     return True

--- a/custom_components/foxess_modbus/const.py
+++ b/custom_components/foxess_modbus/const.py
@@ -29,6 +29,7 @@ PLATFORMS = [SENSOR, BINARY_SENSOR, SELECT, NUMBER]
 ATTR_ENTRY_TYPE = "entry_type"
 
 # Modbus Options
+ENTITY_ID_PREFIX = "entity_id_prefix"
 FRIENDLY_NAME = "friendly_name"
 MODBUS_SLAVE = "modbus_slave"
 MODBUS_DEVICE = "modbus_device"

--- a/custom_components/foxess_modbus/entities/modbus_entity_mixin.py
+++ b/custom_components/foxess_modbus/entities/modbus_entity_mixin.py
@@ -9,6 +9,7 @@ from homeassistant.const import ATTR_MODEL
 from homeassistant.const import ATTR_NAME
 
 from ..const import DOMAIN
+from ..const import ENTITY_ID_PREFIX
 from ..const import FRIENDLY_NAME
 from ..const import INVERTER_CONN
 from ..const import INVERTER_MODEL
@@ -90,9 +91,9 @@ class ModbusEntityMixin(ModbusControllerEntity):
 
     def _get_unique_id(self):
         """Get unique ID"""
-        friendly_name = self._inv_details[FRIENDLY_NAME]
-        if friendly_name != "":
-            return f"{friendly_name}_{self.entity_description.key}"
+        entity_id_prefix = self._inv_details[ENTITY_ID_PREFIX]
+        if entity_id_prefix != "":
+            return f"{entity_id_prefix}_{self.entity_description.key}"
         else:
             return f"{self.entity_description.key}"
 

--- a/custom_components/foxess_modbus/entities/modbus_integration_sensor.py
+++ b/custom_components/foxess_modbus/entities/modbus_integration_sensor.py
@@ -2,10 +2,6 @@
 import logging
 from dataclasses import dataclass
 
-from custom_components.foxess_modbus.const import FRIENDLY_NAME
-from custom_components.foxess_modbus.entities.modbus_entity_mixin import (
-    ModbusEntityMixin,
-)
 from homeassistant.components.integration.sensor import IntegrationSensor
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.sensor import SensorEntityDescription
@@ -16,8 +12,10 @@ from homeassistant.helpers.entity import Entity
 
 from ..common.entity_controller import EntityController
 from ..common.register_type import RegisterType
+from ..const import ENTITY_ID_PREFIX
 from .entity_factory import EntityFactory
 from .inverter_model_spec import EntitySpec
+from .modbus_entity_mixin import ModbusEntityMixin
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -90,9 +88,9 @@ class ModbusIntegrationSensor(ModbusEntityMixin, IntegrationSensor):
         self.entity_description = entity_description
         self.entity_id = "sensor." + self._get_unique_id()
 
-        friendly_name = self._inv_details[FRIENDLY_NAME]
-        if friendly_name != "":
-            source_entity = f"sensor.{friendly_name}_{source_entity}"
+        entity_id_prefix = self._inv_details[ENTITY_ID_PREFIX]
+        if entity_id_prefix != "":
+            source_entity = f"sensor.{entity_id_prefix}_{source_entity}"
         else:
             source_entity = f"sensor.{source_entity}"
 

--- a/custom_components/foxess_modbus/translations/en.json
+++ b/custom_components/foxess_modbus/translations/en.json
@@ -39,12 +39,15 @@
         }
       },
       "friendly_name": {
-        "description": "If you have more than one inverter, give them each a name to tell them apart.",
+        "description": "If you have more than one inverter, give this one a name to tell them apart.",
         "data": {
-          "friendly_name": "Friendly Name"
+          "friendly_name": "Friendly Name",
+          "autogenerate_entity_id_prefix": "Use the Friendly Name to auto-generate a prefix for all entity IDs",
+          "entity_id_prefix": "Entity ID Prefix"
         },
         "data_description": {
-          "friendly_name": "This is added as a prefix to all of the inverter's entity IDs"
+          "friendly_name": "Added to the end of all entity names",
+          "entity_id_prefix": "Added as a prefix to all of this inverter's entity IDs"
         }
       },
       "add_another_inverter": {
@@ -63,10 +66,12 @@
     },
     "error": {
       "duplicate_connection_details": "You have already set up an inverter with this address",
-      "duplicate_friendly_name": "Please enter a unique friendly name",
+      "duplicate_friendly_name": "One of your other inverters has this friendly name. Please specify another",
+      "duplicate_entity_id_prefix": "Please enter a unique entity ID prefix",
+      "unable_to_generate_entity_id_prefix": "Unable to generate a unique entity ID prefix. Please specify one manually",
+      "invalid_entity_id_prefix": "Entity ID prefix must contain only lower-case letters, numbers and underscores",
       "modbus_error": "Error - please check connection details",
-      "modbus_model_not_supported": "Error - model is not supported",
-      "invalid_friendly_name": "Friendly name must contain only lower-case letters, numbers and underscores"
+      "modbus_model_not_supported": "Error - model is not supported"
     },
     "abort": {
       "reconfigure_successful": "Successful. We can now use settings specific to your adapter."

--- a/custom_components/foxess_modbus/translations/en.json
+++ b/custom_components/foxess_modbus/translations/en.json
@@ -69,7 +69,7 @@
       "duplicate_friendly_name": "One of your other inverters has this friendly name. Please specify another",
       "duplicate_entity_id_prefix": "Please enter a unique entity ID prefix",
       "unable_to_generate_entity_id_prefix": "Unable to generate a unique entity ID prefix. Please specify one manually",
-      "invalid_entity_id_prefix": "Entity ID prefix must contain only lower-case letters, numbers and underscores",
+      "invalid_entity_id_prefix": "Entity ID prefix must contain only lower-case letters, numbers and underscores, and must not begin/end with an underscore",
       "modbus_error": "Error - please check connection details",
       "modbus_model_not_supported": "Error - model is not supported"
     },


### PR DESCRIPTION
We now auto-generate an entity ID prefix from the friendly name, and use that in entity IDs.

There's a checkbox to let the user specify their own entity ID prefix.

We handle the case where we can't generate a unique entity ID prefix by prompting the user.

Add a migration to copy friendly name into entity_id_prefix.

Fixes: #183 

![image](https://user-images.githubusercontent.com/568104/234611858-80ed67f4-5639-43c8-9ef9-b7e0e57bc886.png)

![image](https://user-images.githubusercontent.com/568104/234611918-4039cdd0-c6f1-4656-84a7-e42e92abfd0c.png)

![image](https://user-images.githubusercontent.com/568104/234612001-703be125-1b02-49f8-aadc-cae2a52c71f7.png)

![image](https://user-images.githubusercontent.com/568104/234612141-3c5021c7-0e1c-48d5-9ba1-b644204aabea.png)

![image](https://user-images.githubusercontent.com/568104/234612197-21b7dd7d-5e9a-4ce2-90f9-849ce28a3849.png)

