### PR TITLE
Change the device class on charge period binary sensors

### DIFF
--- a/custom_components/foxess_modbus/entities/modbus_charge_period_config.py
+++ b/custom_components/foxess_modbus/entities/modbus_charge_period_config.py
@@ -131,7 +131,7 @@ class ModbusChargePeriodFactory:
             address=enable_charge_from_grid_address,
             # The 'Update Charge Period' service only accepts devices with this device_class,
             # so ensure that only inverters which support this provide a sensor with this device_class
-            device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
+            device_class=BinarySensorDeviceClass.POWER,
         )
 
         self.entity_descriptions = [

--- a/custom_components/foxess_modbus/entities/modbus_charge_period_sensors.py
+++ b/custom_components/foxess_modbus/entities/modbus_charge_period_sensors.py
@@ -239,7 +239,7 @@ class ModbusEnableForceChargeSensor(ModbusEntityMixin, BinarySensorEntity):
         self._entry = entry
         self._inv_details = inv_details
         self.entity_id = "binary_sensor." + self._get_unique_id()
-        self._attr_device_class = BinarySensorDeviceClass.BATTERY_CHARGING
+        self._attr_device_class = BinarySensorDeviceClass.POWER
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/foxess_modbus/services.yaml
+++ b/custom_components/foxess_modbus/services.yaml
@@ -45,7 +45,9 @@ update_charge_period:
         device:
           integration: foxess_modbus
           entity:
-            device_class: "battery_charging"
+            # Only charge periods provide binary_sensors with class power, for charge period on/off
+            domain: "binary_sensor"
+            device_class: "power"
     charge_period:
       name: Charge Period
       description: Which charge period to update.
@@ -108,7 +110,9 @@ update_all_charge_periods:
         device:
           integration: foxess_modbus
           entity:
-            device_class: "battery_charging"
+            # Only charge periods provide binary_sensors with class power, for charge period on/off
+            domain: "binary_sensor"
+            device_class: "power"
     charge_periods:
       name: Charge Periods
       description: Charge periods to set. This should be an array of objects, one for each charge period. All charge periods must be specified. See the example data


### PR DESCRIPTION
"POWER" seemed the most appropriate from
https://www.home-assistant.io/integrations/binary_sensor/#device-class

This means that they no longer appear as "Charging" / "Not charging"

See: #69