### PR TITLE
Remove H3 fault code entities

### DIFF
--- a/custom_components/foxess_modbus/entities/entity_descriptions.py
+++ b/custom_components/foxess_modbus/entities/entity_descriptions.py
@@ -1167,24 +1167,25 @@ _INVERTER_ENTITIES = [
         name="Inverter State Code",
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    ModbusSensorDescription(
-        key="fault1_code",
-        addresses=[ModbusAddressesSpec(models=[H3], holding=[31044])],
-        name="Inverter Fault 1 Code",
-        state_class=SensorStateClass.MEASUREMENT,
-    ),
-    ModbusSensorDescription(
-        key="fault2_code",
-        addresses=[ModbusAddressesSpec(models=[H3], holding=[31045])],
-        name="Inverter Fault 2 Code",
-        state_class=SensorStateClass.MEASUREMENT,
-    ),
-    ModbusSensorDescription(
-        key="fault3_code",
-        addresses=[ModbusAddressesSpec(models=[H3], holding=[31046])],
-        name="Inverter Fault 3 Code",
-        state_class=SensorStateClass.MEASUREMENT,
-    ),
+    # We'll re-introduce these as a single sensor showing the current fault code(s)
+    # ModbusSensorDescription(
+    #     key="fault1_code",
+    #     addresses=[ModbusAddressesSpec(models=[H3], holding=[31044])],
+    #     name="Inverter Fault 1 Code",
+    #     state_class=SensorStateClass.MEASUREMENT,
+    # ),
+    # ModbusSensorDescription(
+    #     key="fault2_code",
+    #     addresses=[ModbusAddressesSpec(models=[H3], holding=[31045])],
+    #     name="Inverter Fault 2 Code",
+    #     state_class=SensorStateClass.MEASUREMENT,
+    # ),
+    # ModbusSensorDescription(
+    #     key="fault3_code",
+    #     addresses=[ModbusAddressesSpec(models=[H3], holding=[31046])],
+    #     name="Inverter Fault 3 Code",
+    #     state_class=SensorStateClass.MEASUREMENT,
+    # ),
 ]
 
 _CONFIGURATION_ENTITIES: list[EntityFactory] = [


### PR DESCRIPTION
We now have documentation on fault codes, so we'll re-introduce these as a sensor containing the proper fault code(s)