### PR TITLE
Replace usage of select() with poll() in ModbusTcpClient

### DIFF
--- a/custom_components/foxess_modbus/manifest.json
+++ b/custom_components/foxess_modbus/manifest.json
@@ -8,6 +8,6 @@
   "integration_type": "service",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/nathanmarlor/foxess_modbus/issues",
-  "requirements": ["pymodbus==3.1.3"],
+  "requirements": ["pymodbus==3.2.2"],
   "version": "1.0.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,5 @@ mypy==1.3.0
 homeassistant-stubs==2023.3.0
 types-python-slugify==8.0.0.2
 voluptuous-stubs==0.1.1
-pymodbus==3.1.3 # For mypy
+# For mypy. Keep in sync with manifest.json. If changed, make sure subclasses in modbus_client are still valid!
+pymodbus==3.2.2


### PR DESCRIPTION
select() has a limit of 1024 fds -- if you pass an fd larger than 1024,
it throws a ValueError. This has been previously reported to pymodbus,
but was misdiagnosed as a premature disconnection, see
https://github.com/pymodbus-dev/pymodbus/issues/873.

This affects users whose HA machines maintain lots of open connections /
files.

Fixes: #275