### PR TITLE
Properly disable the built-in mypy

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,9 @@
 {
   "image": "mcr.microsoft.com/vscode/devcontainers/python:0-3.10-bullseye",
   "name": "Foxess Modbus Container",
-  "appPort": ["9123:8123"],
+  "appPort": [
+    "9123:8123"
+  ],
   "postCreateCommand": ".devcontainer/setup",
   "customizations": {
     "vscode": {
@@ -21,8 +23,7 @@
         "python.pythonPath": "/usr/bin/python3",
         "python.analysis.autoSearchPaths": false,
         "python.linting.enabled": true,
-        "python.linting.mypyEnabled": true,
-        "python.analysis.typeCheckingMode": "off",
+        "python.analysis.typeCheckingMode": "off", // Using mypy
         "editor.formatOnPaste": false,
         "editor.formatOnSave": true,
         "editor.formatOnType": true,
@@ -30,7 +31,9 @@
           120 // Matches ruff config
         ],
         "files.trimTrailingWhitespace": true,
-        "mypy.targets": ["custom_components/foxess_modbus"],
+        "mypy.targets": [
+          "custom_components/foxess_modbus"
+        ],
         "python.formatting.provider": "none",
         "[python]": {
           "editor.codeActionsOnSave": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,7 @@
 {
   "image": "mcr.microsoft.com/vscode/devcontainers/python:0-3.10-bullseye",
   "name": "Foxess Modbus Container",
-  "appPort": [
-    "9123:8123"
-  ],
+  "appPort": ["9123:8123"],
   "postCreateCommand": ".devcontainer/setup",
   "customizations": {
     "vscode": {
@@ -14,7 +12,8 @@
         "ms-python.vscode-pylance",
         "github.vscode-pull-request-github",
         "ryanluker.vscode-coverage-gutters",
-        "matangover.mypy"
+        "matangover.mypy",
+        "esbenp.prettier-vscode"
       ],
       "settings": {
         "files.eol": "\n",
@@ -31,10 +30,9 @@
           120 // Matches ruff config
         ],
         "files.trimTrailingWhitespace": true,
-        "mypy.targets": [
-          "custom_components/foxess_modbus"
-        ],
+        "mypy.targets": ["custom_components/foxess_modbus"],
         "python.formatting.provider": "none",
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
         "[python]": {
           "editor.codeActionsOnSave": {
             "source.fixAll": true


### PR DESCRIPTION
Turns out we were running mypy twice: once from the mypy extension (which runs dmypy), and once from one of the built-in python extensions (which runs mypy manually, and is very slow and memory-hungry). Disable the latter.