### PR TITLE
Round rather than truncating number values

### DIFF
--- a/custom_components/foxess_modbus/entities/modbus_number.py
+++ b/custom_components/foxess_modbus/entities/modbus_number.py
@@ -99,7 +99,7 @@ class ModbusNumber(ModbusEntityMixin, NumberEntity):
         if entity_description.scale is not None:
             value = value / entity_description.scale
 
-        int_value = int(value)
+        int_value = int(round(value))
 
         await self._controller.write_register(self._address, int_value)
 


### PR DESCRIPTION
Floating-point inaccuracy means that e.g. 6.6 * 10 = 65.999999.

Fixes: #374