### PR TITLE
Support pymodbus 3.4.1

### DIFF
--- a/custom_components/foxess_modbus/manifest.json
+++ b/custom_components/foxess_modbus/manifest.json
@@ -8,6 +8,6 @@
   "integration_type": "service",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/nathanmarlor/foxess_modbus/issues",
-  "requirements": ["pymodbus==3.1.3"],
+  "requirements": ["pymodbus>=3.1.3"],
   "version": "1.0.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ types-python-slugify==8.0.0.2
 voluptuous-stubs==0.1.1
 # For mypy. Keep in sync with manifest.json and https://github.com/home-assistant/core/blob/master/requirements_all.txt.
 # If changed, make sure subclasses in modbus_client are still valid!
-pymodbus==3.1.3
+pymodbus==3.4.1


### PR DESCRIPTION
HA has upgraded the version it uses. Since we specify a lower version, if there are any other integrations which use the higher version we'll race to see which gets installed first, so there's a chance that we'll end up with 3.4.1.

This matters, because 3.4.1 doesn't have automatic (re)connections.

Fix this. Also relax our range to >=3.1.3, so that if HA upgrades its version again we'll deterministically get the newer version, and if there's a problem we'll know about it, rather than being in a sometimes-working state.

Fixes: #393