### PR TITLE
Remove restrictions on inverter power and EPS power being >=0 for H3

### DIFF
--- a/custom_components/foxess_modbus/entities/entity_descriptions.py
+++ b/custom_components/foxess_modbus/entities/entity_descriptions.py
@@ -617,8 +617,7 @@ _H3_CURRENT_VOLTAGE_POWER_ENTITIES: list[EntityFactory] = [
         native_unit_of_measurement="kW",
         scale=0.001,
         round_to=0.01,
-        post_process=lambda x: max(x, 0),
-        validate=[Range(0, 100)],
+        validate=[Range(-100, 100)],
     ),
     ModbusSensorDescription(
         key="inv_power_S",
@@ -629,8 +628,7 @@ _H3_CURRENT_VOLTAGE_POWER_ENTITIES: list[EntityFactory] = [
         native_unit_of_measurement="kW",
         scale=0.001,
         round_to=0.01,
-        post_process=lambda x: max(x, 0),
-        validate=[Range(0, 100)],
+        validate=[Range(-100, 100)],
     ),
     ModbusSensorDescription(
         key="inv_power_T",
@@ -641,8 +639,7 @@ _H3_CURRENT_VOLTAGE_POWER_ENTITIES: list[EntityFactory] = [
         native_unit_of_measurement="kW",
         scale=0.001,
         round_to=0.01,
-        post_process=lambda x: max(x, 0),
-        validate=[Range(0, 100)],
+        validate=[Range(-100, 100)],
     ),
     ModbusSensorDescription(
         key="eps_power_R",
@@ -655,8 +652,7 @@ _H3_CURRENT_VOLTAGE_POWER_ENTITIES: list[EntityFactory] = [
         icon="mdi:power-socket",
         scale=0.001,
         round_to=0.01,
-        post_process=lambda x: max(x, 0),
-        validate=[Range(0, 100)],
+        validate=[Range(-100, 100)],
     ),
     ModbusSensorDescription(
         key="eps_power_S",
@@ -669,8 +665,7 @@ _H3_CURRENT_VOLTAGE_POWER_ENTITIES: list[EntityFactory] = [
         icon="mdi:power-socket",
         scale=0.001,
         round_to=0.01,
-        post_process=lambda x: max(x, 0),
-        validate=[Range(0, 100)],
+        validate=[Range(-100, 100)],
     ),
     ModbusSensorDescription(
         key="eps_power_T",
@@ -683,8 +678,7 @@ _H3_CURRENT_VOLTAGE_POWER_ENTITIES: list[EntityFactory] = [
         icon="mdi:power-socket",
         scale=0.001,
         round_to=0.01,
-        post_process=lambda x: max(x, 0),
-        validate=[Range(0, 100)],
+        validate=[Range(-100, 100)],
     ),
     ModbusSensorDescription(
         key="grid_ct_R",


### PR DESCRIPTION
Seems that negative values are expected and part of normal operation.

Fixes: #422