### PR TITLE
Print a proper error if the adapter hostname is invalid

### DIFF
--- a/custom_components/foxess_modbus/flow/adapter_flow_segment.py
+++ b/custom_components/foxess_modbus/flow/adapter_flow_segment.py
@@ -1,3 +1,4 @@
+import re
 from typing import Any
 from typing import Awaitable
 from typing import Callable
@@ -135,6 +136,7 @@ class AdapterFlowSegment:
                 user_input.get("protocol_with_recommendation", adapter.network_protocols[0]),
             )
             host = user_input.get("adapter_host", user_input.get("lan_connection_host"))
+            self._validate_hostname(host)
             assert host is not None
             port = user_input.get("adapter_port", _DEFAULT_PORT)
             host_and_port = f"{host}:{port}"
@@ -345,3 +347,7 @@ class AdapterFlowSegment:
                 {"base": "other_inverter_error" if adapter.connection_type == LAN else "other_adapter_error"},
                 error_placeholders={"error_details": get_details(ex, True)},
             ) from ex
+
+    def _validate_hostname(self, host: str) -> None:
+        if not re.fullmatch(r"[a-zA-Z0-9\.\-]+", host):
+            raise ValidationFailedError({"base": "invalid_hostname"}, error_placeholders={"hostname": host})

--- a/custom_components/foxess_modbus/translations/en.json
+++ b/custom_components/foxess_modbus/translations/en.json
@@ -65,6 +65,7 @@
       }
     },
     "error": {
+      "invalid_hostname": "Hostname / IP address '{hostname}' is not valid. Use an IP address (e.g. '192.168.0.10') or a hostname (e.g. 'mydevice' / 'mydevice.local')",
       "duplicate_connection_details": "You have already set up an inverter with this address",
       "duplicate_friendly_name": "One of your other inverters has this friendly name. Please specify another",
       "duplicate_entity_id_prefix": "Please enter a unique entity ID prefix",
@@ -148,6 +149,7 @@
       }
     },
     "error": {
+      "invalid_hostname": "Hostname / IP address '{hostname}' is not valid. Use an IP address (e.g. '192.168.0.10') or a hostname (e.g. 'mydevice' / 'mydevice.local')",
       "duplicate_connection_details": "You have already set up an inverter with this address",
       "inverter_model_not_supported": "Inverter model '{not_supported_model}' is not supported",
       "unable_to_connect_to_adapter": "Unable to connect to your adapter. Ensure that the adapter is properly configured (see the setup link above) and the connection details are correct, then try again. Details: {error_details}",


### PR DESCRIPTION
Previously we concatenated it with the port, then split back out on the first ':'. This caused problems if the user used a hostname of e.g. 'http://foo.bar', as now there were two colons.

Fixes: #464