### PR TITLE
Make dataclasses frozen

### DIFF
--- a/custom_components/foxess_modbus/entities/modbus_battery_sensor.py
+++ b/custom_components/foxess_modbus/entities/modbus_battery_sensor.py
@@ -16,7 +16,7 @@ from .modbus_sensor import ModbusSensor
 from .modbus_sensor import ModbusSensorDescription
 
 
-@dataclass(kw_only=True)
+@dataclass(kw_only=True, frozen=True)
 class ModbusBatterySensorDescription(ModbusSensorDescription):
     """Description for ModbusBatterySensor"""
 

--- a/custom_components/foxess_modbus/entities/modbus_binary_sensor.py
+++ b/custom_components/foxess_modbus/entities/modbus_binary_sensor.py
@@ -23,7 +23,7 @@ from .modbus_entity_mixin import ModbusEntityMixin
 _LOGGER = logging.getLogger(__name__)
 
 
-@dataclass(kw_only=True)
+@dataclass(kw_only=True, frozen=True)
 class ModbusBinarySensorDescription(BinarySensorEntityDescription, EntityFactory):
     """Description for ModbusBinarySensor"""
 

--- a/custom_components/foxess_modbus/entities/modbus_charge_period_config.py
+++ b/custom_components/foxess_modbus/entities/modbus_charge_period_config.py
@@ -22,7 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 # mypy: disable-error-code="call-arg"
 
 
-@dataclass
+@dataclass(frozen=True)
 class ModbusChargePeriodAddressConfig:
     """Defines the set of registers which are used to define a charge period"""
 
@@ -31,7 +31,7 @@ class ModbusChargePeriodAddressConfig:
     enable_charge_from_grid_address: int
 
 
-@dataclass
+@dataclass(frozen=True)
 class ModbusChargePeriodInfo:
     addresses: ModbusChargePeriodAddressConfig
     period_start_entity_id: str
@@ -89,7 +89,7 @@ class ChargePeriodAddressSpec:
         return ModbusAddressSpecBase(self.models, addresses)
 
 
-@dataclass
+@dataclass(frozen=True)
 class ModbusChargePeriodFactory:
     """
     Factory which creates various things required to define and specify a charge period

--- a/custom_components/foxess_modbus/entities/modbus_charge_period_sensors.py
+++ b/custom_components/foxess_modbus/entities/modbus_charge_period_sensors.py
@@ -53,7 +53,7 @@ def _is_force_charge_enabled(
     return start_or_end_1 > 0 or start_or_end_2 > 0
 
 
-@dataclass(kw_only=True)
+@dataclass(kw_only=True, frozen=True)
 class ModbusChargePeriodStartEndSensorDescription(SensorEntityDescription, EntityFactory):
     """Entity description for ModbusChargePeriodStartEndSensor"""
 
@@ -179,7 +179,7 @@ class ModbusChargePeriodStartEndSensor(ModbusEntityMixin, RestoreEntity, SensorE
         return [self._address, self._other_address]
 
 
-@dataclass(kw_only=True)
+@dataclass(kw_only=True, frozen=True)
 class ModbusEnableForceChargeSensorDescription(BinarySensorEntityDescription, EntityFactory):
     """Entity description for ModbusEnableForceChargeSensor"""
 

--- a/custom_components/foxess_modbus/entities/modbus_fault_sensor.py
+++ b/custom_components/foxess_modbus/entities/modbus_fault_sensor.py
@@ -155,7 +155,7 @@ for assert_fault, assert_masks in _MASKS.items():
         assert any(fault for fault_list in _FAULTS for fault in fault_list if fault == assert_mask)
 
 
-@dataclass(kw_only=True)
+@dataclass(kw_only=True, frozen=True)
 class ModbusFaultSensorDescription(SensorEntityDescription, EntityFactory):
     """Description for ModbusFaultSensor"""
 

--- a/custom_components/foxess_modbus/entities/modbus_inverter_state_sensor.py
+++ b/custom_components/foxess_modbus/entities/modbus_inverter_state_sensor.py
@@ -37,7 +37,7 @@ KH_INVERTER_STATES = [
 ]
 
 
-@dataclass(kw_only=True)
+@dataclass(kw_only=True, frozen=True)
 class ModbusInverterStateSensorDescription(SensorEntityDescription, EntityFactory):
     """Description for ModbusInverterStateSensor"""
 

--- a/custom_components/foxess_modbus/entities/modbus_lambda_sensor.py
+++ b/custom_components/foxess_modbus/entities/modbus_lambda_sensor.py
@@ -23,7 +23,7 @@ from .modbus_entity_mixin import get_entity_id
 _LOGGER = logging.getLogger(__name__)
 
 
-@dataclass(kw_only=True)
+@dataclass(kw_only=True, frozen=True)
 class ModbusLambdaSensorDescription(SensorEntityDescription, EntityFactory):
     """Entity description for ModbusLambdaSensors"""
 

--- a/custom_components/foxess_modbus/entities/modbus_number.py
+++ b/custom_components/foxess_modbus/entities/modbus_number.py
@@ -24,7 +24,7 @@ from .modbus_entity_mixin import ModbusEntityMixin
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 
-@dataclass(kw_only=True)
+@dataclass(kw_only=True, frozen=True)
 class ModbusNumberDescription(NumberEntityDescription, EntityFactory):
     """Custom number entity description"""
 

--- a/custom_components/foxess_modbus/entities/modbus_sensor.py
+++ b/custom_components/foxess_modbus/entities/modbus_sensor.py
@@ -25,7 +25,7 @@ from .modbus_entity_mixin import ModbusEntityMixin
 _LOGGER = logging.getLogger(__name__)
 
 
-@dataclass(kw_only=True)
+@dataclass(kw_only=True, frozen=True)
 class ModbusSensorDescription(SensorEntityDescription, EntityFactory):
     """Custom sensor description"""
 


### PR DESCRIPTION
HA is moving to a model where dataclasses need to be frozen (to aid caching), and will start logging depreciation warnings in 2024.x. Let's get ahead of the game.

See https://github.com/home-assistant/core/pull/105211