### PR TITLE
Parse the inverter capacity from the model name

### DIFF
--- a/custom_components/foxess_modbus/common/entity_controller.py
+++ b/custom_components/foxess_modbus/common/entity_controller.py
@@ -96,6 +96,11 @@ class EntityController(ABC):
     def remote_control_manager(self) -> EntityRemoteControlManager | None:
         """Fetch the remote control manager, if any"""
 
+    @property
+    @abstractmethod
+    def inverter_capacity(self) -> int:
+        """Fetches the inverter capacity as parsed from the inverter name, if possible"""
+
     @abstractmethod
     def register_modbus_entity(self, listener: ModbusControllerEntity) -> None:
         """Register a modbus entity with the ModbusController"""

--- a/custom_components/foxess_modbus/entities/modbus_remote_control_config.py
+++ b/custom_components/foxess_modbus/entities/modbus_remote_control_config.py
@@ -15,9 +15,6 @@ from .inverter_model_spec import ModbusAddressSpecBase
 from .modbus_remote_control_number import ModbusRemoteControlNumberDescription
 from .modbus_remote_control_select import ModbusRemoteControlSelectDescription
 
-# H3-12.0
-MAX_INVERTER_POWER = 12000
-
 
 @dataclass(frozen=True)
 class ModbusRemoteControlAddressConfig:
@@ -123,7 +120,7 @@ class ModbusRemoteControlFactory:
             name="Force Charge Power",
             models=all_models,
             max_value_address=ac_power_limit_down_address,
-            fallback_native_max_value=-MAX_INVERTER_POWER,
+            fallback_native_max_value=lambda x: -x.inverter_capacity,  # - to counteract -ve scale
             mode=NumberMode.BOX,
             device_class=NumberDeviceClass.POWER,
             native_min_value=0.0,
@@ -145,7 +142,7 @@ class ModbusRemoteControlFactory:
             name="Force Discharge Power",
             models=all_models,
             max_value_address=ac_power_limit_down_address,
-            fallback_native_max_value=-MAX_INVERTER_POWER,
+            fallback_native_max_value=lambda x: -x.inverter_capacity,  # - to counteract -ve scale
             mode=NumberMode.BOX,
             device_class=NumberDeviceClass.POWER,
             native_min_value=0.0,
@@ -174,7 +171,7 @@ class ModbusRemoteControlFactory:
             models=[x.get_models_without_max_soc() for x in self.address_specs],
             max_value_address=None,
             native_min_value=0.0,
-            fallback_native_max_value=100,
+            fallback_native_max_value=lambda _x: 100,
             mode=NumberMode.BOX,
             device_class=NumberDeviceClass.BATTERY,
             # Max value is read from the inverter

--- a/custom_components/foxess_modbus/entities/modbus_remote_control_number.py
+++ b/custom_components/foxess_modbus/entities/modbus_remote_control_number.py
@@ -33,7 +33,7 @@ class ModbusRemoteControlNumberDescription(NumberEntityDescription, EntityFactor
 
     models: list[EntitySpec]
     max_value_address: list[InverterModelSpec] | None
-    fallback_native_max_value: int
+    fallback_native_max_value: Callable[[EntityController], int]
     """Used if the max_value_address isn't available for an inverter"""
     mode: NumberMode = NumberMode.AUTO
     scale: float = 1.0
@@ -117,7 +117,7 @@ class ModbusRemoteControlNumber(ModbusEntityMixin, RestoreNumber, NumberEntity):
         max_value = (
             self._controller.read(self._max_value_address, signed=entity_description.signed)
             if self._max_value_address is not None
-            else entity_description.fallback_native_max_value
+            else entity_description.fallback_native_max_value(self._controller)
         )
         if max_value is not None:
             native_max_value = max_value * entity_description.scale

--- a/custom_components/foxess_modbus/modbus_controller.py
+++ b/custom_components/foxess_modbus/modbus_controller.py
@@ -30,6 +30,7 @@ from .common.register_type import RegisterType
 from .common.unload_controller import UnloadController
 from .const import DOMAIN
 from .const import FRIENDLY_NAME
+from .const import INVERTER_MODEL
 from .const import MAX_READ
 from .inverter_profiles import INVERTER_PROFILES
 from .inverter_profiles import InverterModelConnectionTypeProfile
@@ -102,6 +103,7 @@ class ModbusController(EntityController, UnloadController):
         # To start, we're neither connected nor disconnected
         self._connection_state = ConnectionState.INITIAL
         self._current_connection_error: str | None = None
+        self._inverter_capacity = connection_type_profile.inverter_capacity(self.inverter_details[INVERTER_MODEL])
 
         # Setup mixins
         EntityController.__init__(self)
@@ -133,6 +135,10 @@ class ModbusController(EntityController, UnloadController):
     @property
     def remote_control_manager(self) -> EntityRemoteControlManager | None:
         return self._remote_control_manager
+
+    @property
+    def inverter_capacity(self) -> int:
+        return self._inverter_capacity
 
     def read(self, address: int, *, signed: bool) -> int | None:
         # There can be a delay between writing a register, and actually reading that value back (presumably the delay


### PR DESCRIPTION
It seems the KH starts exporting if you tell it to import at a power which is greater than its capacity. We can't get the capacity any other way.

Leave ac_power_limit_down in for now, although strictly speaking it's redundant.

See: #518 