### PR TITLE
Remove the 41000 registers from the AIO-H3

### DIFF
--- a/custom_components/foxess_modbus/common/types.py
+++ b/custom_components/foxess_modbus/common/types.py
@@ -56,8 +56,9 @@ class Inv(Flag):
     KH_SET = KH_PRE119 | KH_119
 
     H3 = auto()
+    AIO_H3 = auto()
     KUARA_H3 = auto()
-    H3_SET = H3 | KUARA_H3
+    H3_SET = H3 | AIO_H3 | KUARA_H3
 
     ALL = H1_LAN | H1_G1 | KH_SET | H3_SET
 

--- a/custom_components/foxess_modbus/entities/entity_descriptions.py
+++ b/custom_components/foxess_modbus/entities/entity_descriptions.py
@@ -1597,7 +1597,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="work_mode",
         address=[
             ModbusAddressSpec(input=41000, models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressSpec(holding=41000, models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressSpec(holding=41000, models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
         ],
         name="Work Mode",
         options_map={0: "Self Use", 1: "Feed-in First", 2: "Back-up"},
@@ -1607,7 +1607,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="max_charge_current",
         addresses=[
             ModbusAddressesSpec(input=[41007], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[41007], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressesSpec(holding=[41007], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
         ],
         name="Max Charge Current",
         device_class=SensorDeviceClass.CURRENT,
@@ -1620,7 +1620,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="max_charge_current",
         address=[
             ModbusAddressSpec(input=41007, models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressSpec(holding=41007, models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressSpec(holding=41007, models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
         ],
         name="Max Charge Current",
         mode=NumberMode.BOX,
@@ -1636,7 +1636,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="max_discharge_current",
         addresses=[
             ModbusAddressesSpec(input=[41008], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[41008], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressesSpec(holding=[41008], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
         ],
         name="Max Discharge Current",
         device_class=SensorDeviceClass.CURRENT,
@@ -1649,7 +1649,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="max_discharge_current",
         address=[
             ModbusAddressSpec(input=41008, models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressSpec(holding=41008, models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressSpec(holding=41008, models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
         ],
         name="Max Discharge Current",
         mode=NumberMode.BOX,
@@ -1666,7 +1666,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="min_soc",
         addresses=[
             ModbusAddressesSpec(input=[41009], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[41009], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressesSpec(holding=[41009], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
         ],
         name="Min SoC",
         device_class=SensorDeviceClass.BATTERY,
@@ -1679,7 +1679,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="min_soc",
         address=[
             ModbusAddressSpec(input=41009, models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressSpec(holding=41009, models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressSpec(holding=41009, models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
         ],
         name="Min SoC",
         mode=NumberMode.BOX,
@@ -1696,7 +1696,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="max_soc",
         addresses=[
             ModbusAddressesSpec(input=[41010], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[41010], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressesSpec(holding=[41010], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
         ],
         name="Max SoC",
         device_class=SensorDeviceClass.BATTERY,
@@ -1709,7 +1709,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="max_soc",
         address=[
             ModbusAddressSpec(input=41010, models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressSpec(holding=41010, models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressSpec(holding=41010, models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
         ],
         name="Max SoC",
         mode=NumberMode.BOX,
@@ -1726,7 +1726,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="min_soc_on_grid",
         addresses=[
             ModbusAddressesSpec(input=[41011], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[41011], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressesSpec(holding=[41011], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
         ],
         name="Min SoC (On Grid)",
         device_class=SensorDeviceClass.BATTERY,
@@ -1739,7 +1739,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="min_soc_on_grid",
         address=[
             ModbusAddressSpec(input=41011, models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressSpec(holding=41011, models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressSpec(holding=41011, models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
         ],
         name="Min SoC (On Grid)",
         mode=NumberMode.BOX,

--- a/custom_components/foxess_modbus/entities/remote_control_description.py
+++ b/custom_components/foxess_modbus/entities/remote_control_description.py
@@ -82,7 +82,7 @@ REMOTE_CONTROL_DESCRIPTION = ModbusRemoteControlFactory(
                 pwr_limit_bat_up=None,
                 pv_voltages=[31000, 31003],
             ),
-            models=Inv.H3_SET & ~Inv.KUARA_H3,
+            models=Inv.H3_SET & ~Inv.KUARA_H3 & ~Inv.AIO_H3,
         ),
     ]
 )

--- a/custom_components/foxess_modbus/inverter_profiles.py
+++ b/custom_components/foxess_modbus/inverter_profiles.py
@@ -243,7 +243,7 @@ INVERTER_PROFILES = {
         ),
         InverterModelProfile(InverterModel.AIO_H3, r"^AIO-H3-([\d\.]+)")
         .add_connection_type(
-            Inv.H3,
+            Inv.AIO_H3,
             ConnectionType.AUX,
             RegisterType.HOLDING,
             special_registers=H3_REGISTERS,


### PR DESCRIPTION
Looks like they don't work, see
https://github.com/nathanmarlor/foxess_modbus/discussions/566

Fixes: #569