### PR TITLE
H1 Gen2 Inverter support

### DIFF
--- a/custom_components/foxess_modbus/common/types.py
+++ b/custom_components/foxess_modbus/common/types.py
@@ -35,8 +35,9 @@ class InverterModel(StrEnum):
     as config[INVERTER_BASE].
     """
 
-    H1 = "H1"
-    
+    H1_G1 = "H1"  # Can't change the value, as it's set in people's configs
+    H1_G2 = "H1_G2"
+
     AC1 = "AC1"
     AIO_H1 = "AIO-H1"
 

--- a/custom_components/foxess_modbus/common/types.py
+++ b/custom_components/foxess_modbus/common/types.py
@@ -36,6 +36,7 @@ class InverterModel(StrEnum):
     """
 
     H1 = "H1"
+    
     AC1 = "AC1"
     AIO_H1 = "AIO-H1"
 
@@ -59,6 +60,7 @@ class Inv(Flag):
 
     H1_LAN = auto()
     H1_G1 = auto()
+    H1_G2 = auto()
 
     KH_PRE119 = auto()
     KH_119 = auto()
@@ -69,7 +71,7 @@ class Inv(Flag):
     KUARA_H3 = auto()
     H3_SET = H3 | AIO_H3 | KUARA_H3
 
-    ALL = H1_LAN | H1_G1 | KH_SET | H3_SET
+    ALL = H1_LAN | H1_G1 | H1_G2 | KH_SET | H3_SET
 
 
 class RegisterPollType(IntEnum):

--- a/custom_components/foxess_modbus/entities/charge_period_descriptions.py
+++ b/custom_components/foxess_modbus/entities/charge_period_descriptions.py
@@ -18,8 +18,16 @@ CHARGE_PERIODS = [
                     period_end_address=41003,
                     enable_charge_from_grid_address=41001,
                 ),
-                models=Inv.H1_G1 | Inv.H1_G2 | Inv.KH_PRE119,
-            )
+                models=Inv.H1_G1 | Inv.KH_PRE119,
+            ),
+            ChargePeriodAddressSpec(
+                holding=ModbusChargePeriodAddressConfig(
+                    period_start_address=41002,
+                    period_end_address=41003,
+                    enable_charge_from_grid_address=41001,
+                ),
+                models=Inv.H1_G2,
+            ),
         ],
         period_start_key="time_period_1_start",
         period_start_name="Period 1 - Start",
@@ -38,8 +46,16 @@ CHARGE_PERIODS = [
                     period_end_address=41006,
                     enable_charge_from_grid_address=41004,
                 ),
-                models=Inv.H1_G1 | Inv.H1_G2 | Inv.KH_PRE119,
-            )
+                models=Inv.H1_G1 | Inv.KH_PRE119,
+            ),
+            ChargePeriodAddressSpec(
+                holding=ModbusChargePeriodAddressConfig(
+                    period_start_address=41005,
+                    period_end_address=41006,
+                    enable_charge_from_grid_address=41004,
+                ),
+                models=Inv.H1_G2,
+            ),
         ],
         period_start_key="time_period_2_start",
         period_start_name="Period 2 - Start",

--- a/custom_components/foxess_modbus/entities/charge_period_descriptions.py
+++ b/custom_components/foxess_modbus/entities/charge_period_descriptions.py
@@ -18,7 +18,7 @@ CHARGE_PERIODS = [
                     period_end_address=41003,
                     enable_charge_from_grid_address=41001,
                 ),
-                models=Inv.H1_G1 | Inv.KH_PRE119,
+                models=Inv.H1_G1 | Inv.H1_G2 | Inv.KH_PRE119,
             )
         ],
         period_start_key="time_period_1_start",
@@ -38,7 +38,7 @@ CHARGE_PERIODS = [
                     period_end_address=41006,
                     enable_charge_from_grid_address=41004,
                 ),
-                models=Inv.H1_G1 | Inv.KH_PRE119,
+                models=Inv.H1_G1 | Inv.H1_G2 | Inv.KH_PRE119,
             )
         ],
         period_start_key="time_period_2_start",

--- a/custom_components/foxess_modbus/entities/entity_descriptions.py
+++ b/custom_components/foxess_modbus/entities/entity_descriptions.py
@@ -21,6 +21,7 @@ from .modbus_fault_sensor import ModbusFaultSensorDescription
 from .modbus_integration_sensor import ModbusIntegrationSensorDescription
 from .modbus_inverter_state_sensor import H1_INVERTER_STATES
 from .modbus_inverter_state_sensor import KH_INVERTER_STATES
+from .modbus_inverter_state_sensor import ModbusG2InverterStateSensorDescription
 from .modbus_inverter_state_sensor import ModbusInverterStateSensorDescription
 from .modbus_lambda_sensor import ModbusLambdaSensorDescription
 from .modbus_number import ModbusNumberDescription
@@ -1283,7 +1284,6 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         address=[
             ModbusAddressSpec(input=11056, models=Inv.H1_G1),
             ModbusAddressSpec(holding=31027, models=Inv.H1_G1 | Inv.H1_LAN),
-            ModbusAddressSpec(holding=39063, models=Inv.H1_G2),
         ],
         name="Inverter State",
         states=H1_INVERTER_STATES,
@@ -1296,6 +1296,13 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         ],
         name="Inverter State",
         states=KH_INVERTER_STATES,
+    )
+    yield ModbusG2InverterStateSensorDescription(
+        key="inverter_state",
+        addresses=[
+            ModbusAddressesSpec(holding=[39063, 39065], models=Inv.H1_G2),
+        ],
+        name="Inverter State",
     )
     yield ModbusSensorDescription(
         key="state_code",

--- a/custom_components/foxess_modbus/entities/entity_descriptions.py
+++ b/custom_components/foxess_modbus/entities/entity_descriptions.py
@@ -1073,7 +1073,6 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         addresses=[
             ModbusAddressesSpec(input=[11034], models=Inv.H1_G1 | Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[31034], models=Inv.H3_SET),
-            ModbusAddressesSpec(holding=[31020], models=Inv.H1_G2),
         ],
         name="Battery Voltage",
         device_class=SensorDeviceClass.VOLTAGE,
@@ -1088,7 +1087,6 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         addresses=[
             ModbusAddressesSpec(input=[11035], models=Inv.H1_G1 | Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[31035], models=Inv.H3_SET),
-            ModbusAddressesSpec(holding=[31021], models=Inv.H1_G2),
         ],
         name="Battery Current",
         device_class=SensorDeviceClass.CURRENT,

--- a/custom_components/foxess_modbus/entities/entity_descriptions.py
+++ b/custom_components/foxess_modbus/entities/entity_descriptions.py
@@ -271,7 +271,6 @@ def _pv_entities() -> Iterable[EntityFactory]:
         addresses=[
             ModbusAddressesSpec(input=[11096], models=Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[31039], models=Inv.KH_119),
-            ModbusAddressesSpec(holding=[39074], models=Inv.H1_G2),
         ],
         name="PV3 Voltage",
     )
@@ -280,7 +279,6 @@ def _pv_entities() -> Iterable[EntityFactory]:
         addresses=[
             ModbusAddressesSpec(input=[11097], models=Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[31040], models=Inv.KH_119),
-            ModbusAddressesSpec(holding=[39075], models=Inv.H1_G2),
         ],
         name="PV3 Current",
     )
@@ -289,7 +287,6 @@ def _pv_entities() -> Iterable[EntityFactory]:
         addresses=[
             ModbusAddressesSpec(input=[11098], models=Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[31041], models=Inv.KH_119),
-            ModbusAddressesSpec(holding=[39284, 39283], models=Inv.H1_G2),
         ],
         name="PV3 Power",
     )
@@ -309,7 +306,6 @@ def _pv_entities() -> Iterable[EntityFactory]:
         addresses=[
             ModbusAddressesSpec(input=[11099], models=Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[31042], models=Inv.KH_119),
-            ModbusAddressesSpec(holding=[39076], models=Inv.H1_G2),
         ],
         name="PV4 Voltage",
     )
@@ -318,7 +314,6 @@ def _pv_entities() -> Iterable[EntityFactory]:
         addresses=[
             ModbusAddressesSpec(input=[11100], models=Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[31043], models=Inv.KH_119),
-            ModbusAddressesSpec(holding=[39077], models=Inv.H1_G2),
         ],
         name="PV4 Current",
     )
@@ -327,7 +322,6 @@ def _pv_entities() -> Iterable[EntityFactory]:
         addresses=[
             ModbusAddressesSpec(input=[11101], models=Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[31044], models=Inv.KH_119),
-            ModbusAddressesSpec(holding=[39286, 39285], models=Inv.H1_G2),
         ],
         name="PV4 Power",
     )

--- a/custom_components/foxess_modbus/entities/entity_descriptions.py
+++ b/custom_components/foxess_modbus/entities/entity_descriptions.py
@@ -133,7 +133,7 @@ def _pv_entities() -> Iterable[EntityFactory]:
             # This can go negative if no panels are attached
         )
 
-    def _pv_current(key: str, addresses: list[ModbusAddressesSpec], name: str) -> EntityFactory:
+    def _pv_current(key: str, addresses: list[ModbusAddressesSpec], name: str, scale: float = 0.1) -> EntityFactory:
         return ModbusSensorDescription(
             key=key,
             addresses=addresses,
@@ -141,7 +141,7 @@ def _pv_entities() -> Iterable[EntityFactory]:
             device_class=SensorDeviceClass.CURRENT,
             state_class=SensorStateClass.MEASUREMENT,
             native_unit_of_measurement="A",
-            scale=0.1,
+            scale=scale,
             round_to=1,
             # This can a small amount negative
             post_process=lambda x: max(x, 0),
@@ -190,9 +190,16 @@ def _pv_entities() -> Iterable[EntityFactory]:
         addresses=[
             ModbusAddressesSpec(input=[11001], models=Inv.H1_G1 | Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[31001], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H3_SET),
+        ],
+        name="PV1 Current",
+    )
+    yield _pv_current(
+        key="pv1_current",
+        addresses=[
             ModbusAddressesSpec(holding=[39071], models=Inv.H1_G2),
         ],
         name="PV1 Current",
+        scale=0.01,
     )
     yield _pv_power(
         key="pv1_power",
@@ -228,9 +235,16 @@ def _pv_entities() -> Iterable[EntityFactory]:
         addresses=[
             ModbusAddressesSpec(input=[11004], models=Inv.H1_G1 | Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[31004], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H3_SET),
+        ],
+        name="PV2 Current",
+    )
+    yield _pv_current(
+        key="pv2_current",
+        addresses=[
             ModbusAddressesSpec(holding=[39073], models=Inv.H1_G2),
         ],
         name="PV2 Current",
+        scale=0.01,
     )
     yield _pv_power(
         key="pv2_power",

--- a/custom_components/foxess_modbus/entities/entity_descriptions.py
+++ b/custom_components/foxess_modbus/entities/entity_descriptions.py
@@ -39,7 +39,7 @@ from .validation import Range
 BMS_CONNECT_STATE_ADDRESS = [
     ModbusAddressSpec(input=11058, models=Inv.H1_G1 | Inv.KH_PRE119),
     ModbusAddressSpec(holding=31029, models=Inv.H1_G1 | Inv.H1_LAN),
-    ModbusAddressSpec(holding=31028, models=Inv.KH_119),
+    ModbusAddressSpec(holding=31028, models=Inv.KH_119 | Inv.H1_G2),
     ModbusAddressSpec(holding=31042, models=Inv.H3_SET),
 ]
 
@@ -65,6 +65,7 @@ def _version_entities() -> Iterable[EntityFactory]:
     yield _master_version(
         address=[
             ModbusAddressSpec(holding=30016, models=Inv.KH_119),
+            ModbusAddressSpec(holding=36001, models=Inv.H1_G2),
         ],
         is_hex=True,
     )
@@ -88,6 +89,7 @@ def _version_entities() -> Iterable[EntityFactory]:
     yield _slave_version(
         address=[
             ModbusAddressSpec(holding=30017, models=Inv.KH_119),
+            ModbusAddressSpec(holding=36002, models=Inv.H1_G2),
         ],
         is_hex=True,
     )
@@ -111,6 +113,7 @@ def _version_entities() -> Iterable[EntityFactory]:
     yield _manager_version(
         address=[
             ModbusAddressSpec(holding=30018, models=Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressSpec(holding=36003, models=Inv.H1_G2),
         ],
         is_hex=True,
     )
@@ -178,6 +181,7 @@ def _pv_entities() -> Iterable[EntityFactory]:
         addresses=[
             ModbusAddressesSpec(input=[11000], models=Inv.H1_G1 | Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[31000], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressesSpec(holding=[39070], models=Inv.H1_G2),
         ],
         name="PV1 Voltage",
     )
@@ -186,6 +190,7 @@ def _pv_entities() -> Iterable[EntityFactory]:
         addresses=[
             ModbusAddressesSpec(input=[11001], models=Inv.H1_G1 | Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[31001], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressesSpec(holding=[39071], models=Inv.H1_G2),
         ],
         name="PV1 Current",
     )
@@ -194,6 +199,7 @@ def _pv_entities() -> Iterable[EntityFactory]:
         addresses=[
             ModbusAddressesSpec(input=[11002], models=Inv.H1_G1 | Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[31002], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressesSpec(holding=[39280, 39279], models=Inv.H1_G2),
         ],
         name="PV1 Power",
     )
@@ -213,6 +219,7 @@ def _pv_entities() -> Iterable[EntityFactory]:
         addresses=[
             ModbusAddressesSpec(input=[11003], models=Inv.H1_G1 | Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[31003], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressesSpec(holding=[39072], models=Inv.H1_G2),
         ],
         name="PV2 Voltage",
     )
@@ -221,6 +228,7 @@ def _pv_entities() -> Iterable[EntityFactory]:
         addresses=[
             ModbusAddressesSpec(input=[11004], models=Inv.H1_G1 | Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[31004], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressesSpec(holding=[39073], models=Inv.H1_G2),
         ],
         name="PV2 Current",
     )
@@ -229,6 +237,7 @@ def _pv_entities() -> Iterable[EntityFactory]:
         addresses=[
             ModbusAddressesSpec(input=[11005], models=Inv.H1_G1 | Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[31005], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressesSpec(holding=[39282, 39281], models=Inv.H1_G2),
         ],
         name="PV2 Power",
     )
@@ -248,6 +257,7 @@ def _pv_entities() -> Iterable[EntityFactory]:
         addresses=[
             ModbusAddressesSpec(input=[11096], models=Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[31039], models=Inv.KH_119),
+            ModbusAddressesSpec(holding=[39074], models=Inv.H1_G2),
         ],
         name="PV3 Voltage",
     )
@@ -256,6 +266,7 @@ def _pv_entities() -> Iterable[EntityFactory]:
         addresses=[
             ModbusAddressesSpec(input=[11097], models=Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[31040], models=Inv.KH_119),
+            ModbusAddressesSpec(holding=[39073], models=Inv.H1_G2),
         ],
         name="PV3 Current",
     )
@@ -264,6 +275,7 @@ def _pv_entities() -> Iterable[EntityFactory]:
         addresses=[
             ModbusAddressesSpec(input=[11098], models=Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[31041], models=Inv.KH_119),
+            ModbusAddressesSpec(holding=[39284, 39283], models=Inv.H1_G2),
         ],
         name="PV3 Power",
     )
@@ -283,6 +295,7 @@ def _pv_entities() -> Iterable[EntityFactory]:
         addresses=[
             ModbusAddressesSpec(input=[11099], models=Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[31042], models=Inv.KH_119),
+            ModbusAddressesSpec(holding=[39076], models=Inv.H1_G2),
         ],
         name="PV4 Voltage",
     )
@@ -291,6 +304,7 @@ def _pv_entities() -> Iterable[EntityFactory]:
         addresses=[
             ModbusAddressesSpec(input=[11100], models=Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[31043], models=Inv.KH_119),
+            ModbusAddressesSpec(holding=[39077], models=Inv.H1_G2),
         ],
         name="PV4 Current",
     )
@@ -299,6 +313,7 @@ def _pv_entities() -> Iterable[EntityFactory]:
         addresses=[
             ModbusAddressesSpec(input=[11101], models=Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[31044], models=Inv.KH_119),
+            ModbusAddressesSpec(holding=[39286, 39285], models=Inv.H1_G2),
         ],
         name="PV4 Power",
     )
@@ -352,7 +367,7 @@ def _h1_current_voltage_power_entities() -> Iterable[EntityFactory]:
         key="invbatvolt",
         addresses=[
             ModbusAddressesSpec(input=[11006], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[31020], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119),
+            ModbusAddressesSpec(holding=[31020], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H1_G2),
         ],
         name="Inverter Battery Voltage",
         device_class=SensorDeviceClass.VOLTAGE,
@@ -366,7 +381,7 @@ def _h1_current_voltage_power_entities() -> Iterable[EntityFactory]:
         key="invbatcurrent",
         addresses=[
             ModbusAddressesSpec(input=[11007], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[31021], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119),
+            ModbusAddressesSpec(holding=[31021], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H1_G2),
         ],
         name="Inverter Battery Current",
         device_class=SensorDeviceClass.CURRENT,
@@ -380,7 +395,7 @@ def _h1_current_voltage_power_entities() -> Iterable[EntityFactory]:
         key="load_power",
         addresses=[
             ModbusAddressesSpec(input=[11023], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[31016], models=Inv.H1_G1 | Inv.H1_LAN),
+            ModbusAddressesSpec(holding=[31016], models=Inv.H1_G1 | Inv.H1_LAN | Inv.H1_G2),
             ModbusAddressesSpec(holding=[31054, 31053], models=Inv.KH_119),
         ],
         name="Load Power",
@@ -396,7 +411,7 @@ def _h1_current_voltage_power_entities() -> Iterable[EntityFactory]:
         key="rvolt",  # Ideally rename to grid_voltage?
         addresses=[
             ModbusAddressesSpec(input=[11009], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[31006], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119),
+            ModbusAddressesSpec(holding=[31006], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H1_G2),
         ],
         entity_registry_enabled_default=False,
         name="Grid Voltage",
@@ -412,7 +427,7 @@ def _h1_current_voltage_power_entities() -> Iterable[EntityFactory]:
         key="rcurrent",
         addresses=[
             ModbusAddressesSpec(input=[11010], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[31007], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119),
+            ModbusAddressesSpec(holding=[31007], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H1_G2),
         ],
         name="Inverter Current",
         device_class=SensorDeviceClass.CURRENT,
@@ -426,7 +441,7 @@ def _h1_current_voltage_power_entities() -> Iterable[EntityFactory]:
         key="rpower",
         addresses=[
             ModbusAddressesSpec(input=[11011], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[31008], models=Inv.H1_G1 | Inv.H1_LAN),
+            ModbusAddressesSpec(holding=[31008], models=Inv.H1_G1 | Inv.H1_LAN | Inv.H1_G2),
             ModbusAddressesSpec(holding=[31046, 31045], models=Inv.KH_119),
         ],
         name="Inverter Power",
@@ -477,7 +492,7 @@ def _h1_current_voltage_power_entities() -> Iterable[EntityFactory]:
         key="eps_rvolt",
         addresses=[
             ModbusAddressesSpec(input=[11015], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[31010], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119),
+            ModbusAddressesSpec(holding=[31010], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H1_G2),
         ],
         entity_registry_enabled_default=False,
         name="EPS Voltage",
@@ -493,7 +508,7 @@ def _h1_current_voltage_power_entities() -> Iterable[EntityFactory]:
         key="eps_rcurrent",
         addresses=[
             ModbusAddressesSpec(input=[11016], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[31011], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119),
+            ModbusAddressesSpec(holding=[31011], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H1_G2),
         ],
         entity_registry_enabled_default=False,
         name="EPS Current",
@@ -508,7 +523,7 @@ def _h1_current_voltage_power_entities() -> Iterable[EntityFactory]:
         key="eps_rpower",
         addresses=[
             ModbusAddressesSpec(input=[11017], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[31012], models=Inv.H1_G1 | Inv.H1_LAN),
+            ModbusAddressesSpec(holding=[31012], models=Inv.H1_G1 | Inv.H1_LAN | Inv.H1_G2),
             ModbusAddressesSpec(holding=[31048, 31047], models=Inv.KH_119),
         ],
         entity_registry_enabled_default=False,
@@ -602,7 +617,7 @@ def _h1_current_voltage_power_entities() -> Iterable[EntityFactory]:
     yield from _grid_ct(
         addresses=[
             ModbusAddressesSpec(input=[11021], models=Inv.H1_G1),
-            ModbusAddressesSpec(holding=[31014], models=Inv.H1_G1 | Inv.H1_LAN),
+            ModbusAddressesSpec(holding=[31014], models=Inv.H1_G1 | Inv.H1_LAN | Inv.H1_G2),
         ],
         scale=0.001,
     )
@@ -631,7 +646,7 @@ def _h1_current_voltage_power_entities() -> Iterable[EntityFactory]:
     yield _ct2_meter(
         addresses=[
             ModbusAddressesSpec(input=[11022], models=Inv.H1_G1),
-            ModbusAddressesSpec(holding=[31015], models=Inv.H1_G1 | Inv.H1_LAN),
+            ModbusAddressesSpec(holding=[31015], models=Inv.H1_G1 | Inv.H1_LAN | Inv.H1_G2),
         ],
         scale=0.001,
     )
@@ -984,7 +999,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
     yield from _invbatpower(
         addresses=[
             ModbusAddressesSpec(input=[11008], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[31022], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119),
+            ModbusAddressesSpec(holding=[31022], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H1_G2),
             ModbusAddressesSpec(holding=[31036], models=Inv.H3_SET),
         ]
     )
@@ -993,7 +1008,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="rfreq",
         addresses=[
             ModbusAddressesSpec(input=[11014], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[31009], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119),
+            ModbusAddressesSpec(holding=[31009], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H1_G2),
             ModbusAddressesSpec(holding=[31015], models=Inv.H3_SET),
         ],
         entity_registry_enabled_default=False,
@@ -1010,7 +1025,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="eps_frequency",
         addresses=[
             ModbusAddressesSpec(input=[11020], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[31013], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119),
+            ModbusAddressesSpec(holding=[31013], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H1_G2),
             ModbusAddressesSpec(holding=[31025], models=Inv.H3_SET),
         ],
         entity_registry_enabled_default=False,
@@ -1027,7 +1042,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="invtemp",
         addresses=[
             ModbusAddressesSpec(input=[11024], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[31018], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119),
+            ModbusAddressesSpec(holding=[31018], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H1_G2),
             ModbusAddressesSpec(holding=[31032], models=Inv.H3_SET),
         ],
         name="Inverter Temp",
@@ -1042,7 +1057,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="ambtemp",
         addresses=[
             ModbusAddressesSpec(input=[11025], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[31019], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119),
+            ModbusAddressesSpec(holding=[31019], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H1_G2),
             ModbusAddressesSpec(holding=[31033], models=Inv.H3_SET),
         ],
         name="Ambient Temp",
@@ -1058,6 +1073,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         addresses=[
             ModbusAddressesSpec(input=[11034], models=Inv.H1_G1 | Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[31034], models=Inv.H3_SET),
+            ModbusAddressesSpec(holding=[31020], models=Inv.H1_G2),
         ],
         name="Battery Voltage",
         device_class=SensorDeviceClass.VOLTAGE,
@@ -1072,6 +1088,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         addresses=[
             ModbusAddressesSpec(input=[11035], models=Inv.H1_G1 | Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[31035], models=Inv.H3_SET),
+            ModbusAddressesSpec(holding=[31021], models=Inv.H1_G2),
         ],
         name="Battery Current",
         device_class=SensorDeviceClass.CURRENT,
@@ -1085,7 +1102,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="battery_soc",
         addresses=[
             ModbusAddressesSpec(input=[11036], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[31024], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119),
+            ModbusAddressesSpec(holding=[31024], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H1_G2),
             ModbusAddressesSpec(holding=[31038], models=Inv.H3_SET),
         ],
         # TODO: There might be an equivalent register for the H3?
@@ -1101,6 +1118,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="bms_kwh_remaining",
         addresses=[
             ModbusAddressesSpec(input=[11037], models=Inv.H1_G1 | Inv.KH_PRE119),
+            ModbusAddressesSpec(holding=[37632], models=Inv.H1_G2),
         ],
         bms_connect_state_address=BMS_CONNECT_STATE_ADDRESS,
         name="BMS kWh Remaining",
@@ -1117,6 +1135,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
             ModbusAddressesSpec(input=[11038], models=Inv.H1_G1 | Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[31023], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119),
             ModbusAddressesSpec(holding=[31037], models=Inv.H3_SET),
+            ModbusAddressesSpec(holding=[37611], models=Inv.H1_G2),
         ],
         # TODO: There might be an equivalent register for the H3
         bms_connect_state_address=BMS_CONNECT_STATE_ADDRESS,
@@ -1131,7 +1150,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="bms_charge_rate",
         addresses=[
             ModbusAddressesSpec(input=[11041], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[31025], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119),
+            ModbusAddressesSpec(holding=[31025], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H1_G2),
         ],
         entity_registry_enabled_default=False,
         bms_connect_state_address=BMS_CONNECT_STATE_ADDRESS,
@@ -1147,7 +1166,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="bms_discharge_rate",
         addresses=[
             ModbusAddressesSpec(input=[11042], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[31026], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119),
+            ModbusAddressesSpec(holding=[31026], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H1_G2),
         ],
         entity_registry_enabled_default=False,
         bms_connect_state_address=BMS_CONNECT_STATE_ADDRESS,
@@ -1259,6 +1278,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         address=[
             ModbusAddressSpec(input=11056, models=Inv.H1_G1),
             ModbusAddressSpec(holding=31027, models=Inv.H1_G1 | Inv.H1_LAN),
+            ModbusAddressSpec(holding=39063, models=Inv.H1_G2),
         ],
         name="Inverter State",
         states=H1_INVERTER_STATES,
@@ -1285,7 +1305,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="solar_energy_total",
         addresses=[
             ModbusAddressesSpec(input=[11070, 11069], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[32001, 32000], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressesSpec(holding=[32001, 32000], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET | Inv.H1_G2 ),
         ],
         name="Solar Generation Total",
         device_class=SensorDeviceClass.ENERGY,
@@ -1300,7 +1320,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="solar_energy_today",
         addresses=[
             ModbusAddressesSpec(input=[11071], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[32002], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressesSpec(holding=[32002], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET | Inv.H1_G2),
         ],
         name="Solar Generation Today",
         device_class=SensorDeviceClass.ENERGY,
@@ -1315,7 +1335,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="battery_charge_total",
         addresses=[
             ModbusAddressesSpec(input=[11073, 11072], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[32004, 32003], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressesSpec(holding=[32004, 32003], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET | Inv.H1_G2 ),
         ],
         name="Battery Charge Total",
         device_class=SensorDeviceClass.ENERGY,
@@ -1343,7 +1363,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="battery_charge_today",
         addresses=[
             ModbusAddressesSpec(input=[11074], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[32005], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressesSpec(holding=[32005], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET | Inv.H1_G2 ),
         ],
         name="Battery Charge Today",
         device_class=SensorDeviceClass.ENERGY,
@@ -1357,7 +1377,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="battery_discharge_total",
         addresses=[
             ModbusAddressesSpec(input=[11076, 11075], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[32007, 32006], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressesSpec(holding=[32007, 32006], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET | Inv.H1_G2 ),
         ],
         name="Battery Discharge Total",
         device_class=SensorDeviceClass.ENERGY,
@@ -1385,7 +1405,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="battery_discharge_today",
         addresses=[
             ModbusAddressesSpec(input=[11077], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[32008], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressesSpec(holding=[32008], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET | Inv.H1_G2 ),
         ],
         name="Battery Discharge Today",
         device_class=SensorDeviceClass.ENERGY,
@@ -1399,7 +1419,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="feed_in_energy_total",
         addresses=[
             ModbusAddressesSpec(input=[11079, 11078], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[32010, 32009], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressesSpec(holding=[32010, 32009], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET | Inv.H1_G2 ),
         ],
         name="Feed-in Total",
         device_class=SensorDeviceClass.ENERGY,
@@ -1427,7 +1447,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="feed_in_energy_today",
         addresses=[
             ModbusAddressesSpec(input=[11080], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[32011], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressesSpec(holding=[32011], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET | Inv.H1_G2 ),
         ],
         name="Feed-in Today",
         device_class=SensorDeviceClass.ENERGY,
@@ -1441,7 +1461,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="grid_consumption_energy_total",
         addresses=[
             ModbusAddressesSpec(input=[11082, 11081], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[32013, 32012], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressesSpec(holding=[32013, 32012], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET | Inv.H1_G2 ),
         ],
         name="Grid Consumption Total",
         device_class=SensorDeviceClass.ENERGY,
@@ -1469,7 +1489,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="grid_consumption_energy_today",
         addresses=[
             ModbusAddressesSpec(input=[11083], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[32014], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressesSpec(holding=[32014], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET | Inv.H1_G2 ),
         ],
         name="Grid Consumption Today",
         device_class=SensorDeviceClass.ENERGY,
@@ -1483,7 +1503,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="total_yield_total",
         addresses=[
             ModbusAddressesSpec(input=[11085, 11084], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[32016, 32015], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressesSpec(holding=[32016, 32015], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET | Inv.H1_G2 ),
         ],
         name="Yield Total",
         device_class=SensorDeviceClass.ENERGY,
@@ -1498,7 +1518,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="total_yield_today",
         addresses=[
             ModbusAddressesSpec(input=[11086], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[32017], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressesSpec(holding=[32017], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET  | Inv.H1_G2 ),
         ],
         name="Yield Today",
         device_class=SensorDeviceClass.ENERGY,
@@ -1513,7 +1533,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="input_energy_total",
         addresses=[
             ModbusAddressesSpec(input=[11088, 11087], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[32019, 32018], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressesSpec(holding=[32019, 32018], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET | Inv.H1_G2 ),
         ],
         name="Input Energy Total",
         device_class=SensorDeviceClass.ENERGY,
@@ -1528,7 +1548,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="input_energy_today",
         addresses=[
             ModbusAddressesSpec(input=[11089], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[32020], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressesSpec(holding=[32020], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET | Inv.H1_G2 ),
         ],
         name="Input Energy Today",
         device_class=SensorDeviceClass.ENERGY,
@@ -1547,7 +1567,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
             #     models=H1_SET, input=[11091, 11090]
             # ),
             ModbusAddressesSpec(input=[11091, 11090], models=Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[32022, 32021], models=Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressesSpec(holding=[32022, 32021], models=Inv.KH_119 | Inv.H3_SET | Inv.H1_G2 ),
         ],
         name="Load Energy Total",
         device_class=SensorDeviceClass.ENERGY,
@@ -1578,7 +1598,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="load_energy_today",
         addresses=[
             ModbusAddressesSpec(input=[11092], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[32023], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET),
+            ModbusAddressesSpec(holding=[32023], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET  | Inv.H1_G2 ),
         ],
         name="Load Energy Today",
         device_class=SensorDeviceClass.ENERGY,
@@ -1596,7 +1616,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="work_mode",
         address=[
             ModbusAddressSpec(input=41000, models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressSpec(holding=41000, models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
+            ModbusAddressSpec(holding=41000, models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3 | Inv.H1_G2 ),
         ],
         name="Work Mode",
         options_map={0: "Self Use", 1: "Feed-in First", 2: "Back-up"},
@@ -1606,7 +1626,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="max_charge_current",
         addresses=[
             ModbusAddressesSpec(input=[41007], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[41007], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
+            ModbusAddressesSpec(holding=[41007], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3 | Inv.H1_G2 ),
         ],
         name="Max Charge Current",
         device_class=SensorDeviceClass.CURRENT,
@@ -1619,7 +1639,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="max_charge_current",
         address=[
             ModbusAddressSpec(input=41007, models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressSpec(holding=41007, models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
+            ModbusAddressSpec(holding=41007, models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3 | Inv.H1_G2),
         ],
         name="Max Charge Current",
         mode=NumberMode.BOX,
@@ -1635,7 +1655,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="max_discharge_current",
         addresses=[
             ModbusAddressesSpec(input=[41008], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[41008], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
+            ModbusAddressesSpec(holding=[41008], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3 | Inv.H1_G2),
         ],
         name="Max Discharge Current",
         device_class=SensorDeviceClass.CURRENT,
@@ -1648,7 +1668,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="max_discharge_current",
         address=[
             ModbusAddressSpec(input=41008, models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressSpec(holding=41008, models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
+            ModbusAddressSpec(holding=41008, models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3 | Inv.H1_G2),
         ],
         name="Max Discharge Current",
         mode=NumberMode.BOX,
@@ -1665,7 +1685,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="min_soc",
         addresses=[
             ModbusAddressesSpec(input=[41009], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[41009], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
+            ModbusAddressesSpec(holding=[41009], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3 | Inv.H1_G2),
         ],
         name="Min SoC",
         device_class=SensorDeviceClass.BATTERY,
@@ -1678,7 +1698,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="min_soc",
         address=[
             ModbusAddressSpec(input=41009, models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressSpec(holding=41009, models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
+            ModbusAddressSpec(holding=41009, models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3 | Inv.H1_G2),
         ],
         name="Min SoC",
         mode=NumberMode.BOX,
@@ -1695,7 +1715,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="max_soc",
         addresses=[
             ModbusAddressesSpec(input=[41010], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[41010], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
+            ModbusAddressesSpec(holding=[41010], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3 | Inv.H1_G2),
         ],
         name="Max SoC",
         device_class=SensorDeviceClass.BATTERY,
@@ -1708,7 +1728,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="max_soc",
         address=[
             ModbusAddressSpec(input=41010, models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressSpec(holding=41010, models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
+            ModbusAddressSpec(holding=41010, models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3 | Inv.H1_G2),
         ],
         name="Max SoC",
         mode=NumberMode.BOX,
@@ -1725,7 +1745,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="min_soc_on_grid",
         addresses=[
             ModbusAddressesSpec(input=[41011], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[41011], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
+            ModbusAddressesSpec(holding=[41011], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3 | Inv.H1_G2),
         ],
         name="Min SoC (On Grid)",
         device_class=SensorDeviceClass.BATTERY,
@@ -1738,7 +1758,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="min_soc_on_grid",
         address=[
             ModbusAddressSpec(input=41011, models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressSpec(holding=41011, models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
+            ModbusAddressSpec(holding=41011, models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3 | Inv.H1_G2),
         ],
         name="Min SoC (On Grid)",
         mode=NumberMode.BOX,

--- a/custom_components/foxess_modbus/entities/entity_descriptions.py
+++ b/custom_components/foxess_modbus/entities/entity_descriptions.py
@@ -1139,8 +1139,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="battery_temp",
         addresses=[
             ModbusAddressesSpec(input=[11038], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[31023], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119),
-            ModbusAddressesSpec(holding=[37611], models=Inv.H1_G2),
+            ModbusAddressesSpec(holding=[31023], models=Inv.H1_G1 | Inv.H1_LAN | Inv.H1_G2 | Inv.KH_119),
             ModbusAddressesSpec(holding=[31037], models=Inv.H3_SET),
         ],
         # TODO: There might be an equivalent register for the H3

--- a/custom_components/foxess_modbus/entities/entity_descriptions.py
+++ b/custom_components/foxess_modbus/entities/entity_descriptions.py
@@ -266,7 +266,7 @@ def _pv_entities() -> Iterable[EntityFactory]:
         addresses=[
             ModbusAddressesSpec(input=[11097], models=Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[31040], models=Inv.KH_119),
-            ModbusAddressesSpec(holding=[39073], models=Inv.H1_G2),
+            ModbusAddressesSpec(holding=[39075], models=Inv.H1_G2),
         ],
         name="PV3 Current",
     )

--- a/custom_components/foxess_modbus/entities/entity_descriptions.py
+++ b/custom_components/foxess_modbus/entities/entity_descriptions.py
@@ -367,7 +367,7 @@ def _h1_current_voltage_power_entities() -> Iterable[EntityFactory]:
         key="invbatvolt",
         addresses=[
             ModbusAddressesSpec(input=[11006], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[31020], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H1_G2),
+            ModbusAddressesSpec(holding=[31020], models=Inv.H1_G1 | Inv.H1_LAN | Inv.H1_G2 | Inv.KH_119),
         ],
         name="Inverter Battery Voltage",
         device_class=SensorDeviceClass.VOLTAGE,
@@ -381,7 +381,7 @@ def _h1_current_voltage_power_entities() -> Iterable[EntityFactory]:
         key="invbatcurrent",
         addresses=[
             ModbusAddressesSpec(input=[11007], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[31021], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H1_G2),
+            ModbusAddressesSpec(holding=[31021], models=Inv.H1_G1 | Inv.H1_LAN | Inv.H1_G2 | Inv.KH_119),
         ],
         name="Inverter Battery Current",
         device_class=SensorDeviceClass.CURRENT,
@@ -411,7 +411,7 @@ def _h1_current_voltage_power_entities() -> Iterable[EntityFactory]:
         key="rvolt",  # Ideally rename to grid_voltage?
         addresses=[
             ModbusAddressesSpec(input=[11009], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[31006], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H1_G2),
+            ModbusAddressesSpec(holding=[31006], models=Inv.H1_G1 | Inv.H1_LAN | Inv.H1_G2 | Inv.KH_119),
         ],
         entity_registry_enabled_default=False,
         name="Grid Voltage",
@@ -427,7 +427,7 @@ def _h1_current_voltage_power_entities() -> Iterable[EntityFactory]:
         key="rcurrent",
         addresses=[
             ModbusAddressesSpec(input=[11010], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[31007], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H1_G2),
+            ModbusAddressesSpec(holding=[31007], models=Inv.H1_G1 | Inv.H1_LAN | Inv.H1_G2 | Inv.KH_119),
         ],
         name="Inverter Current",
         device_class=SensorDeviceClass.CURRENT,
@@ -492,7 +492,7 @@ def _h1_current_voltage_power_entities() -> Iterable[EntityFactory]:
         key="eps_rvolt",
         addresses=[
             ModbusAddressesSpec(input=[11015], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[31010], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H1_G2),
+            ModbusAddressesSpec(holding=[31010], models=Inv.H1_G1 | Inv.H1_LAN | Inv.H1_G2 | Inv.KH_119),
         ],
         entity_registry_enabled_default=False,
         name="EPS Voltage",
@@ -508,7 +508,7 @@ def _h1_current_voltage_power_entities() -> Iterable[EntityFactory]:
         key="eps_rcurrent",
         addresses=[
             ModbusAddressesSpec(input=[11016], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[31011], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H1_G2),
+            ModbusAddressesSpec(holding=[31011], models=Inv.H1_G1 | Inv.H1_LAN | Inv.H1_G2 | Inv.KH_119),
         ],
         entity_registry_enabled_default=False,
         name="EPS Current",
@@ -999,7 +999,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
     yield from _invbatpower(
         addresses=[
             ModbusAddressesSpec(input=[11008], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[31022], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H1_G2),
+            ModbusAddressesSpec(holding=[31022], models=Inv.H1_G1 | Inv.H1_LAN | Inv.H1_G2 | Inv.KH_119),
             ModbusAddressesSpec(holding=[31036], models=Inv.H3_SET),
         ]
     )
@@ -1008,7 +1008,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="rfreq",
         addresses=[
             ModbusAddressesSpec(input=[11014], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[31009], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H1_G2),
+            ModbusAddressesSpec(holding=[31009], models=Inv.H1_G1 | Inv.H1_LAN | Inv.H1_G2 | Inv.KH_119),
             ModbusAddressesSpec(holding=[31015], models=Inv.H3_SET),
         ],
         entity_registry_enabled_default=False,
@@ -1025,7 +1025,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="eps_frequency",
         addresses=[
             ModbusAddressesSpec(input=[11020], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[31013], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H1_G2),
+            ModbusAddressesSpec(holding=[31013], models=Inv.H1_G1 | Inv.H1_LAN | Inv.H1_G2 | Inv.KH_119),
             ModbusAddressesSpec(holding=[31025], models=Inv.H3_SET),
         ],
         entity_registry_enabled_default=False,
@@ -1042,7 +1042,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="invtemp",
         addresses=[
             ModbusAddressesSpec(input=[11024], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[31018], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H1_G2),
+            ModbusAddressesSpec(holding=[31018], models=Inv.H1_G1 | Inv.H1_LAN | Inv.H1_G2 | Inv.KH_119),
             ModbusAddressesSpec(holding=[31032], models=Inv.H3_SET),
         ],
         name="Inverter Temp",
@@ -1057,7 +1057,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="ambtemp",
         addresses=[
             ModbusAddressesSpec(input=[11025], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[31019], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H1_G2),
+            ModbusAddressesSpec(holding=[31019], models=Inv.H1_G1 | Inv.H1_LAN | Inv.H1_G2 | Inv.KH_119),
             ModbusAddressesSpec(holding=[31033], models=Inv.H3_SET),
         ],
         name="Ambient Temp",
@@ -1102,7 +1102,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="battery_soc",
         addresses=[
             ModbusAddressesSpec(input=[11036], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[31024], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H1_G2),
+            ModbusAddressesSpec(holding=[31024], models=Inv.H1_G1 | Inv.H1_LAN | Inv.H1_G2 | Inv.KH_119),
             ModbusAddressesSpec(holding=[31038], models=Inv.H3_SET),
         ],
         # TODO: There might be an equivalent register for the H3?
@@ -1134,8 +1134,8 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         addresses=[
             ModbusAddressesSpec(input=[11038], models=Inv.H1_G1 | Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[31023], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119),
-            ModbusAddressesSpec(holding=[31037], models=Inv.H3_SET),
             ModbusAddressesSpec(holding=[37611], models=Inv.H1_G2),
+            ModbusAddressesSpec(holding=[31037], models=Inv.H3_SET),
         ],
         # TODO: There might be an equivalent register for the H3
         bms_connect_state_address=BMS_CONNECT_STATE_ADDRESS,
@@ -1150,7 +1150,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="bms_charge_rate",
         addresses=[
             ModbusAddressesSpec(input=[11041], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[31025], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H1_G2),
+            ModbusAddressesSpec(holding=[31025], models=Inv.H1_G1 | Inv.H1_LAN | Inv.H1_G2 | Inv.KH_119),
         ],
         entity_registry_enabled_default=False,
         bms_connect_state_address=BMS_CONNECT_STATE_ADDRESS,
@@ -1166,7 +1166,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="bms_discharge_rate",
         addresses=[
             ModbusAddressesSpec(input=[11042], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[31026], models=Inv.H1_G1 | Inv.H1_LAN | Inv.KH_119 | Inv.H1_G2),
+            ModbusAddressesSpec(holding=[31026], models=Inv.H1_G1 | Inv.H1_LAN | Inv.H1_G2 | Inv.KH_119),
         ],
         entity_registry_enabled_default=False,
         bms_connect_state_address=BMS_CONNECT_STATE_ADDRESS,
@@ -1305,7 +1305,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="solar_energy_total",
         addresses=[
             ModbusAddressesSpec(input=[11070, 11069], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[32001, 32000], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET | Inv.H1_G2 ),
+            ModbusAddressesSpec(holding=[32001, 32000], models=Inv.H1_G1 | Inv.KH_119 | Inv.H1_G2 | Inv.H3_SET),
         ],
         name="Solar Generation Total",
         device_class=SensorDeviceClass.ENERGY,
@@ -1320,7 +1320,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="solar_energy_today",
         addresses=[
             ModbusAddressesSpec(input=[11071], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[32002], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET | Inv.H1_G2),
+            ModbusAddressesSpec(holding=[32002], models=Inv.H1_G1 | Inv.KH_119 | Inv.H1_G2 | Inv.H3_SET),
         ],
         name="Solar Generation Today",
         device_class=SensorDeviceClass.ENERGY,
@@ -1335,7 +1335,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="battery_charge_total",
         addresses=[
             ModbusAddressesSpec(input=[11073, 11072], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[32004, 32003], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET | Inv.H1_G2 ),
+            ModbusAddressesSpec(holding=[32004, 32003], models=Inv.H1_G1 | Inv.KH_119 | Inv.H1_G2 | Inv.H3_SET),
         ],
         name="Battery Charge Total",
         device_class=SensorDeviceClass.ENERGY,
@@ -1363,7 +1363,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="battery_charge_today",
         addresses=[
             ModbusAddressesSpec(input=[11074], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[32005], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET | Inv.H1_G2 ),
+            ModbusAddressesSpec(holding=[32005], models=Inv.H1_G1 | Inv.KH_119 | Inv.H1_G2 | Inv.H3_SET),
         ],
         name="Battery Charge Today",
         device_class=SensorDeviceClass.ENERGY,
@@ -1377,7 +1377,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="battery_discharge_total",
         addresses=[
             ModbusAddressesSpec(input=[11076, 11075], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[32007, 32006], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET | Inv.H1_G2 ),
+            ModbusAddressesSpec(holding=[32007, 32006], models=Inv.H1_G1 | Inv.KH_119 | Inv.H1_G2 | Inv.H3_SET),
         ],
         name="Battery Discharge Total",
         device_class=SensorDeviceClass.ENERGY,
@@ -1405,7 +1405,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="battery_discharge_today",
         addresses=[
             ModbusAddressesSpec(input=[11077], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[32008], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET | Inv.H1_G2 ),
+            ModbusAddressesSpec(holding=[32008], models=Inv.H1_G1 | Inv.KH_119 | Inv.H1_G2 | Inv.H3_SET),
         ],
         name="Battery Discharge Today",
         device_class=SensorDeviceClass.ENERGY,
@@ -1419,7 +1419,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="feed_in_energy_total",
         addresses=[
             ModbusAddressesSpec(input=[11079, 11078], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[32010, 32009], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET | Inv.H1_G2 ),
+            ModbusAddressesSpec(holding=[32010, 32009], models=Inv.H1_G1 | Inv.KH_119 | Inv.H1_G2 | Inv.H3_SET),
         ],
         name="Feed-in Total",
         device_class=SensorDeviceClass.ENERGY,
@@ -1447,7 +1447,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="feed_in_energy_today",
         addresses=[
             ModbusAddressesSpec(input=[11080], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[32011], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET | Inv.H1_G2 ),
+            ModbusAddressesSpec(holding=[32011], models=Inv.H1_G1 | Inv.KH_119 | Inv.H1_G2 | Inv.H3_SET),
         ],
         name="Feed-in Today",
         device_class=SensorDeviceClass.ENERGY,
@@ -1461,7 +1461,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="grid_consumption_energy_total",
         addresses=[
             ModbusAddressesSpec(input=[11082, 11081], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[32013, 32012], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET | Inv.H1_G2 ),
+            ModbusAddressesSpec(holding=[32013, 32012], models=Inv.H1_G1 | Inv.KH_119 | Inv.H1_G2 | Inv.H3_SET),
         ],
         name="Grid Consumption Total",
         device_class=SensorDeviceClass.ENERGY,
@@ -1489,7 +1489,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="grid_consumption_energy_today",
         addresses=[
             ModbusAddressesSpec(input=[11083], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[32014], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET | Inv.H1_G2 ),
+            ModbusAddressesSpec(holding=[32014], models=Inv.H1_G1 | Inv.KH_119 | Inv.H1_G2 | Inv.H3_SET),
         ],
         name="Grid Consumption Today",
         device_class=SensorDeviceClass.ENERGY,
@@ -1503,7 +1503,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="total_yield_total",
         addresses=[
             ModbusAddressesSpec(input=[11085, 11084], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[32016, 32015], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET | Inv.H1_G2 ),
+            ModbusAddressesSpec(holding=[32016, 32015], models=Inv.H1_G1 | Inv.KH_119 | Inv.H1_G2 | Inv.H3_SET),
         ],
         name="Yield Total",
         device_class=SensorDeviceClass.ENERGY,
@@ -1518,7 +1518,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="total_yield_today",
         addresses=[
             ModbusAddressesSpec(input=[11086], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[32017], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET  | Inv.H1_G2 ),
+            ModbusAddressesSpec(holding=[32017], models=Inv.H1_G1 | Inv.KH_119 | Inv.H1_G2 | Inv.H3_SET),
         ],
         name="Yield Today",
         device_class=SensorDeviceClass.ENERGY,
@@ -1533,7 +1533,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="input_energy_total",
         addresses=[
             ModbusAddressesSpec(input=[11088, 11087], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[32019, 32018], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET | Inv.H1_G2 ),
+            ModbusAddressesSpec(holding=[32019, 32018], models=Inv.H1_G1 | Inv.KH_119 | Inv.H1_G2 | Inv.H3_SET),
         ],
         name="Input Energy Total",
         device_class=SensorDeviceClass.ENERGY,
@@ -1548,7 +1548,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="input_energy_today",
         addresses=[
             ModbusAddressesSpec(input=[11089], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[32020], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET | Inv.H1_G2 ),
+            ModbusAddressesSpec(holding=[32020], models=Inv.H1_G1 | Inv.KH_119 | Inv.H1_G2 | Inv.H3_SET),
         ],
         name="Input Energy Today",
         device_class=SensorDeviceClass.ENERGY,
@@ -1567,7 +1567,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
             #     models=H1_SET, input=[11091, 11090]
             # ),
             ModbusAddressesSpec(input=[11091, 11090], models=Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[32022, 32021], models=Inv.KH_119 | Inv.H3_SET | Inv.H1_G2 ),
+            ModbusAddressesSpec(holding=[32022, 32021], models=Inv.KH_119 | Inv.H1_G2 | Inv.H3_SET),
         ],
         name="Load Energy Total",
         device_class=SensorDeviceClass.ENERGY,
@@ -1598,7 +1598,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         key="load_energy_today",
         addresses=[
             ModbusAddressesSpec(input=[11092], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[32023], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET  | Inv.H1_G2 ),
+            ModbusAddressesSpec(holding=[32023], models=Inv.H1_G1 | Inv.KH_119 | Inv.H1_G2 | Inv.H3_SET),
         ],
         name="Load Energy Today",
         device_class=SensorDeviceClass.ENERGY,
@@ -1616,7 +1616,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="work_mode",
         address=[
             ModbusAddressSpec(input=41000, models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressSpec(holding=41000, models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3 | Inv.H1_G2 ),
+            ModbusAddressSpec(holding=41000, models=Inv.H1_G1 | Inv.H1_G2 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
         ],
         name="Work Mode",
         options_map={0: "Self Use", 1: "Feed-in First", 2: "Back-up"},
@@ -1626,7 +1626,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="max_charge_current",
         addresses=[
             ModbusAddressesSpec(input=[41007], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[41007], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3 | Inv.H1_G2 ),
+            ModbusAddressesSpec(holding=[41007], models=Inv.H1_G1 | Inv.H1_G2 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
         ],
         name="Max Charge Current",
         device_class=SensorDeviceClass.CURRENT,
@@ -1639,7 +1639,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="max_charge_current",
         address=[
             ModbusAddressSpec(input=41007, models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressSpec(holding=41007, models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3 | Inv.H1_G2),
+            ModbusAddressSpec(holding=41007, models=Inv.H1_G1 | Inv.H1_G2 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
         ],
         name="Max Charge Current",
         mode=NumberMode.BOX,
@@ -1655,7 +1655,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="max_discharge_current",
         addresses=[
             ModbusAddressesSpec(input=[41008], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[41008], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3 | Inv.H1_G2),
+            ModbusAddressesSpec(holding=[41008], models=Inv.H1_G1 | Inv.H1_G2 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
         ],
         name="Max Discharge Current",
         device_class=SensorDeviceClass.CURRENT,
@@ -1668,7 +1668,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="max_discharge_current",
         address=[
             ModbusAddressSpec(input=41008, models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressSpec(holding=41008, models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3 | Inv.H1_G2),
+            ModbusAddressSpec(holding=41008, models=Inv.H1_G1 | Inv.H1_G2 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
         ],
         name="Max Discharge Current",
         mode=NumberMode.BOX,
@@ -1685,7 +1685,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="min_soc",
         addresses=[
             ModbusAddressesSpec(input=[41009], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[41009], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3 | Inv.H1_G2),
+            ModbusAddressesSpec(holding=[41009], models=Inv.H1_G1 | Inv.H1_G2 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
         ],
         name="Min SoC",
         device_class=SensorDeviceClass.BATTERY,
@@ -1698,7 +1698,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="min_soc",
         address=[
             ModbusAddressSpec(input=41009, models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressSpec(holding=41009, models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3 | Inv.H1_G2),
+            ModbusAddressSpec(holding=41009, models=Inv.H1_G1 | Inv.H1_G2 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
         ],
         name="Min SoC",
         mode=NumberMode.BOX,
@@ -1715,7 +1715,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="max_soc",
         addresses=[
             ModbusAddressesSpec(input=[41010], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[41010], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3 | Inv.H1_G2),
+            ModbusAddressesSpec(holding=[41010], models=Inv.H1_G1 | Inv.H1_G2 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
         ],
         name="Max SoC",
         device_class=SensorDeviceClass.BATTERY,
@@ -1728,7 +1728,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="max_soc",
         address=[
             ModbusAddressSpec(input=41010, models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressSpec(holding=41010, models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3 | Inv.H1_G2),
+            ModbusAddressSpec(holding=41010, models=Inv.H1_G1 | Inv.H1_G2 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
         ],
         name="Max SoC",
         mode=NumberMode.BOX,
@@ -1745,7 +1745,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="min_soc_on_grid",
         addresses=[
             ModbusAddressesSpec(input=[41011], models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressesSpec(holding=[41011], models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3 | Inv.H1_G2),
+            ModbusAddressesSpec(holding=[41011], models=Inv.H1_G1 | Inv.H1_G2 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
         ],
         name="Min SoC (On Grid)",
         device_class=SensorDeviceClass.BATTERY,
@@ -1758,7 +1758,7 @@ def _configuration_entities() -> Iterable[EntityFactory]:
         key="min_soc_on_grid",
         address=[
             ModbusAddressSpec(input=41011, models=Inv.H1_G1 | Inv.KH_PRE119),
-            ModbusAddressSpec(holding=41011, models=Inv.H1_G1 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3 | Inv.H1_G2),
+            ModbusAddressSpec(holding=41011, models=Inv.H1_G1 | Inv.H1_G2 | Inv.KH_119 | Inv.H3_SET & ~Inv.AIO_H3),
         ],
         name="Min SoC (On Grid)",
         mode=NumberMode.BOX,

--- a/custom_components/foxess_modbus/entities/remote_control_description.py
+++ b/custom_components/foxess_modbus/entities/remote_control_description.py
@@ -46,7 +46,7 @@ REMOTE_CONTROL_DESCRIPTION = ModbusRemoteControlFactory(
                 max_soc=41010,
                 invbatpower=31022,
                 battery_soc=31024,
-                pwr_limit_bat_up=None,
+                pwr_limit_bat_up=44012,
                 pv_voltages=[39070, 39072],
             ),
             models=Inv.H1_G2,

--- a/custom_components/foxess_modbus/entities/remote_control_description.py
+++ b/custom_components/foxess_modbus/entities/remote_control_description.py
@@ -36,6 +36,21 @@ REMOTE_CONTROL_DESCRIPTION = ModbusRemoteControlFactory(
             ),
             models=Inv.H1_LAN,
         ),
+        RemoteControlAddressSpec(
+            holding=ModbusRemoteControlAddressConfig(
+                remote_enable=44000,
+                timeout_set=44001,
+                active_power=[44002],
+                ac_power_limit_down=None,
+                work_mode=41000,
+                max_soc=41010,
+                invbatpower=31022,
+                battery_soc=31024,
+                pwr_limit_bat_up=None,
+                pv_voltages=[39070, 39072, 39074, 39076],
+            ),
+            models=Inv.H1_G2,
+        ),
         # The KH doesn't support anything above 44003
         RemoteControlAddressSpec(
             input=ModbusRemoteControlAddressConfig(
@@ -66,21 +81,6 @@ REMOTE_CONTROL_DESCRIPTION = ModbusRemoteControlFactory(
                 pv_voltages=[31000, 31003, 31039, 31042],
             ),
             models=Inv.KH_119,
-        ),
-        RemoteControlAddressSpec(
-            holding=ModbusRemoteControlAddressConfig(
-                remote_enable=44000,
-                timeout_set=44001,
-                active_power=[44002],
-                ac_power_limit_down=None,
-                work_mode=41000,
-                max_soc=41010,
-                invbatpower=31022,
-                battery_soc=31024,
-                pwr_limit_bat_up=None,
-                pv_voltages=[39070, 39072, 39074, 39076],
-            ),
-            models=Inv.H1_G2,
         ),
         RemoteControlAddressSpec(
             # The H3 doesn't support anything above 44005, and the active/reactive power regisers are 2 values

--- a/custom_components/foxess_modbus/entities/remote_control_description.py
+++ b/custom_components/foxess_modbus/entities/remote_control_description.py
@@ -68,6 +68,21 @@ REMOTE_CONTROL_DESCRIPTION = ModbusRemoteControlFactory(
             models=Inv.KH_119,
         ),
         RemoteControlAddressSpec(
+            holding=ModbusRemoteControlAddressConfig(
+                remote_enable=44000,
+                timeout_set=44001,
+                active_power=[44002],
+                ac_power_limit_down=None,
+                work_mode=41000,
+                max_soc=41010,
+                invbatpower=31022,
+                battery_soc=31024,
+                pwr_limit_bat_up=None,
+                pv_voltages=[39070, 39072, 39074, 39076],
+            ),
+            models=Inv.H1_G2,
+        ),
+        RemoteControlAddressSpec(
             # The H3 doesn't support anything above 44005, and the active/reactive power regisers are 2 values
             # The Kuara H3 doesn't support this, see https://github.com/nathanmarlor/foxess_modbus/issues/532
             holding=ModbusRemoteControlAddressConfig(

--- a/custom_components/foxess_modbus/entities/remote_control_description.py
+++ b/custom_components/foxess_modbus/entities/remote_control_description.py
@@ -47,7 +47,7 @@ REMOTE_CONTROL_DESCRIPTION = ModbusRemoteControlFactory(
                 invbatpower=31022,
                 battery_soc=31024,
                 pwr_limit_bat_up=None,
-                pv_voltages=[39070, 39072, 39074, 39076],
+                pv_voltages=[39070, 39072],
             ),
             models=Inv.H1_G2,
         ),

--- a/custom_components/foxess_modbus/inverter_profiles.py
+++ b/custom_components/foxess_modbus/inverter_profiles.py
@@ -54,6 +54,7 @@ H1_G2_REGISTERS = SpecialRegisterConfig(
     individual_read_register_ranges=[(41000, 41999)],
 )
 
+
 class InverterModelConnectionTypeProfile:
     """Describes the capabilities of an inverter when connected to over a particular interface"""
 
@@ -172,8 +173,15 @@ class InverterModelProfile:
 INVERTER_PROFILES = {
     x.model: x
     for x in [
+        # E.g. H1-5.0-E-G2. Has to appear before H1_G1.
+        InverterModelProfile(InverterModel.H1_G2, r"^H1-([\d\.]+)-E-G2").add_connection_type(
+            Inv.H1_G2,
+            ConnectionType.AUX,
+            RegisterType.HOLDING,
+            special_registers=H1_G2_REGISTERS,
+        ),
         # Can be both e.g. H1-5.0 and H1-5.0-E, but not H1-5.0-E-G2
-        InverterModelProfile(InverterModel.H1, r"^H1-([\d\.]+)(-E)*(?<!-G2)$")
+        InverterModelProfile(InverterModel.H1_G1, r"^H1-([\d\.]+)")
         .add_connection_type(
             Inv.H1_G1,
             ConnectionType.AUX,
@@ -184,14 +192,6 @@ INVERTER_PROFILES = {
             Inv.H1_LAN,
             ConnectionType.LAN,
             RegisterType.HOLDING,
-        ),
-        # H1 G2 models have a different register map}
-        InverterModelProfile(InverterModel.H1, r"^H1-([\d\.]+)-E-G2")
-        .add_connection_type(
-            Inv.H1_G2,
-            ConnectionType.AUX,
-            RegisterType.HOLDING,
-            special_registers=H1_G2_REGISTERS,
         ),
         InverterModelProfile(InverterModel.AC1, r"^AC1-([\d\.]+)")
         .add_connection_type(
@@ -320,7 +320,7 @@ def create_entities(
     controller: EntityController,
 ) -> list[Entity]:
     """Create all of the entities which support the inverter described by the given configuration object"""
-    
+
     return inverter_connection_type_profile_from_config(controller.inverter_details).create_entities(
         entity_type, controller
     )


### PR DESCRIPTION
First go at H1-*-G2 modbus support based on the register mapping at

https://github.com/TonyM1958/HA-FoxESS-Modbus/blob/main/custom_components/HA-FoxESS-Modbus/modbusH1G2_RS485_LAN.yaml

Things that don't seem to work:
- Charge periods - can't get the sensors to appear, charge period card doesn't load
- Inverter fault codes - no mapping for these yet
- bms_kwh_remaining is 0.0 kWh (but I just had a cube slave added so the BMS might not have worked it out yet?)