### PR TITLE
Disables use of Pwr_Limit_Bat_Dn on H1 G2

### DIFF
--- a/custom_components/foxess_modbus/entities/remote_control_description.py
+++ b/custom_components/foxess_modbus/entities/remote_control_description.py
@@ -53,7 +53,7 @@ REMOTE_CONTROL_DESCRIPTION = ModbusRemoteControlFactory(
                 max_soc=41010,
                 invbatpower=[31022],
                 battery_soc=[31024],
-                pwr_limit_bat_up=[44012],
+                pwr_limit_bat_up=None,
                 pv_voltages=[39070, 39072],
             ),
             models=Inv.H1_G2,

--- a/custom_components/foxess_modbus/entities/remote_control_description.py
+++ b/custom_components/foxess_modbus/entities/remote_control_description.py
@@ -70,6 +70,7 @@ REMOTE_CONTROL_DESCRIPTION = ModbusRemoteControlFactory(
                 invbatpower=[11008],
                 battery_soc=[11036],
                 pwr_limit_bat_up=None,
+                # Exists, but see https://github.com/nathanmarlor/foxess_modbus/discussions/666
                 pv_voltages=[11000, 11003, 11096, 11099],
             ),
             models=Inv.KH_PRE119,


### PR DESCRIPTION
This register is not supported on H1 Gen 2 which results in Force Charge fall back to Backup mode.