### PR TITLE
Fix for Force Charge not working when using H1 over LAN

### DIFF
--- a/custom_components/foxess_modbus/remote_control_manager.py
+++ b/custom_components/foxess_modbus/remote_control_manager.py
@@ -272,10 +272,10 @@ class RemoteControlManager(EntityRemoteControlManager, ModbusControllerEntity):
     async def _enable_remote_control(self, fallback_work_mode: WorkMode) -> None:
         # We set a fallback work mode so that the inverter still does "roughly" the right thing if we disconnect
         # (This might not be available, e.g. on H1 LAN)
-        if fallback_work_mode is not None and self._addresses.work_mode_map is not None:
+        if fallback_work_mode is not None and self._addresses.work_mode is not None and self._addresses.work_mode_map is not None:
             fallback_work_mode_value = self._addresses.work_mode_map[fallback_work_mode]
             current_work_mode = self._read(self._addresses.work_mode, signed=False)
-            if current_work_mode != fallback_work_mode_value and self._addresses.work_mode is not None:
+            if current_work_mode != fallback_work_mode_value:
                 await self._controller.write_register(self._addresses.work_mode, fallback_work_mode_value)
 
         if not self._remote_control_enabled:

--- a/custom_components/foxess_modbus/remote_control_manager.py
+++ b/custom_components/foxess_modbus/remote_control_manager.py
@@ -272,10 +272,7 @@ class RemoteControlManager(EntityRemoteControlManager, ModbusControllerEntity):
     async def _enable_remote_control(self, fallback_work_mode: WorkMode) -> None:
         # We set a fallback work mode so that the inverter still does "roughly" the right thing if we disconnect
         # (This might not be available, e.g. on H1 LAN)
-        if (
-            fallback_work_mode is not None
-            and self._addresses.work_mode_map is not None
-        ):
+        if fallback_work_mode is not None and self._addresses.work_mode_map is not None:
             assert self._addresses.work_mode_map is not None
             fallback_work_mode_value = self._addresses.work_mode_map[fallback_work_mode]
 

--- a/custom_components/foxess_modbus/remote_control_manager.py
+++ b/custom_components/foxess_modbus/remote_control_manager.py
@@ -275,7 +275,7 @@ class RemoteControlManager(EntityRemoteControlManager, ModbusControllerEntity):
         if fallback_work_mode is not None and self._addresses.work_mode_map is not None:
             fallback_work_mode_value = self._addresses.work_mode_map[fallback_work_mode]
             current_work_mode = self._read(self._addresses.work_mode, signed=False)
-            if current_work_mode != fallback_work_mode_value:
+            if current_work_mode != fallback_work_mode_value and self._addresses.work_mode is not None:
                 await self._controller.write_register(self._addresses.work_mode, fallback_work_mode_value)
 
         if not self._remote_control_enabled:

--- a/custom_components/foxess_modbus/remote_control_manager.py
+++ b/custom_components/foxess_modbus/remote_control_manager.py
@@ -272,12 +272,16 @@ class RemoteControlManager(EntityRemoteControlManager, ModbusControllerEntity):
     async def _enable_remote_control(self, fallback_work_mode: WorkMode) -> None:
         # We set a fallback work mode so that the inverter still does "roughly" the right thing if we disconnect
         # (This might not be available, e.g. on H1 LAN)
-        assert self._addresses.work_mode_map is not None
-        fallback_work_mode_value = self._addresses.work_mode_map[fallback_work_mode]
+        if (
+            fallback_work_mode is not None
+            and self._addresses.work_mode_map is not None
+        ):
+            assert self._addresses.work_mode_map is not None
+            fallback_work_mode_value = self._addresses.work_mode_map[fallback_work_mode]
 
-        current_work_mode = self._read(self._addresses.work_mode, signed=False)
-        if current_work_mode != fallback_work_mode_value and self._addresses.work_mode is not None:
-            await self._controller.write_register(self._addresses.work_mode, fallback_work_mode_value)
+            current_work_mode = self._read(self._addresses.work_mode, signed=False)
+            if current_work_mode != fallback_work_mode_value and self._addresses.work_mode is not None:
+                await self._controller.write_register(self._addresses.work_mode, fallback_work_mode_value)
 
         if not self._remote_control_enabled:
             self._remote_control_enabled = True

--- a/custom_components/foxess_modbus/remote_control_manager.py
+++ b/custom_components/foxess_modbus/remote_control_manager.py
@@ -272,7 +272,11 @@ class RemoteControlManager(EntityRemoteControlManager, ModbusControllerEntity):
     async def _enable_remote_control(self, fallback_work_mode: WorkMode) -> None:
         # We set a fallback work mode so that the inverter still does "roughly" the right thing if we disconnect
         # (This might not be available, e.g. on H1 LAN)
-        if fallback_work_mode is not None and self._addresses.work_mode is not None and self._addresses.work_mode_map is not None:
+        if (
+            fallback_work_mode is not None
+            and self._addresses.work_mode is not None
+            and self._addresses.work_mode_map is not None
+        ):
             fallback_work_mode_value = self._addresses.work_mode_map[fallback_work_mode]
             current_work_mode = self._read(self._addresses.work_mode, signed=False)
             if current_work_mode != fallback_work_mode_value:

--- a/custom_components/foxess_modbus/remote_control_manager.py
+++ b/custom_components/foxess_modbus/remote_control_manager.py
@@ -273,11 +273,9 @@ class RemoteControlManager(EntityRemoteControlManager, ModbusControllerEntity):
         # We set a fallback work mode so that the inverter still does "roughly" the right thing if we disconnect
         # (This might not be available, e.g. on H1 LAN)
         if fallback_work_mode is not None and self._addresses.work_mode_map is not None:
-            assert self._addresses.work_mode_map is not None
             fallback_work_mode_value = self._addresses.work_mode_map[fallback_work_mode]
-
             current_work_mode = self._read(self._addresses.work_mode, signed=False)
-            if current_work_mode != fallback_work_mode_value and self._addresses.work_mode is not None:
+            if current_work_mode != fallback_work_mode_value:
                 await self._controller.write_register(self._addresses.work_mode, fallback_work_mode_value)
 
         if not self._remote_control_enabled:


### PR DESCRIPTION
It looks like a bug has crept in on the later releases when trying to set force charge for H1 using LAN.

H1 LAN doesn't support work mode hence it is not possible to set a fall back mode and the 'assert if work_mode_map is not None' correctly raises an error for H1 LAN.