### PR TITLE
Add entities for pv5 and pv6 for H3-Pro inverter

### DIFF
--- a/custom_components/foxess_modbus/entities/entity_descriptions.py
+++ b/custom_components/foxess_modbus/entities/entity_descriptions.py
@@ -356,7 +356,7 @@ def _pv_entities() -> Iterable[EntityFactory]:
         addresses=[
             ModbusAddressesSpec(input=[11101], models=Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[31044], models=Inv.KH_119),
-            ModbusAddressesSpec(holding=[39286, 39284], models=Inv.H3_PRO),
+            ModbusAddressesSpec(holding=[39286, 39285], models=Inv.H3_PRO),
         ],
         name="PV4 Power",
     )
@@ -370,6 +370,72 @@ def _pv_entities() -> Iterable[EntityFactory]:
         ],
         name="PV4 Power Total",
         source_entity="pv4_power",
+    )
+    yield _pv_voltage(
+        key="pv5_voltage",
+        addresses=[
+            ModbusAddressesSpec(holding=[39078], models=Inv.H3_PRO),
+        ],
+        name="PV5 Voltage",
+    )
+    yield _pv_current(
+        key="pv5_current",
+        addresses=[
+            ModbusAddressesSpec(holding=[39079], models=Inv.H3_PRO),
+        ],
+        name="PV5 Current",
+        scale=0.01,
+    )
+    yield _pv_power(
+        key="pv5_power",
+        addresses=[
+            ModbusAddressesSpec(holding=[39288, 39287], models=Inv.H3_PRO),
+        ],
+        name="PV5 Power",
+    )
+    yield _pv_energy_total(
+        key="pv5_energy_total",
+        models=[
+            EntitySpec(
+                register_types=[RegisterType.INPUT, RegisterType.HOLDING],
+                models=Inv.H3_PRO,
+            ),
+        ],
+        name="PV5 Power Total",
+        source_entity="pv5_power",
+    )
+    yield _pv_voltage(
+        key="pv6_voltage",
+        addresses=[
+            ModbusAddressesSpec(holding=[39080], models=Inv.H3_PRO),
+        ],
+        name="PV6 Voltage",
+    )
+    yield _pv_current(
+        key="pv6_current",
+        addresses=[
+            ModbusAddressesSpec(holding=[39081], models=Inv.H3_PRO),
+        ],
+        name="PV6 Current",
+        scale=0.01,
+    )
+    yield _pv_power(
+        key="pv6_power",
+        addresses=[
+            ModbusAddressesSpec(holding=[39290, 39289], models=Inv.H3_PRO),
+        ],
+        name="PV6 Power",
+    )
+    yield _pv_energy_total(
+        key="pv6_energy_total",
+        models=[
+            EntitySpec(
+                register_types=[RegisterType.INPUT, RegisterType.HOLDING],
+                models=Inv.H3_PRO,
+            ),
+        ],
+        name="PV6 Power Total",
+        source_entity="pv6_power",
     )
     yield ModbusLambdaSensorDescription(
         key="pv_power_now",
@@ -392,10 +458,26 @@ def _pv_entities() -> Iterable[EntityFactory]:
         models=[
             EntitySpec(
                 register_types=[RegisterType.INPUT, RegisterType.HOLDING],
-                models=Inv.KH_SET | Inv.H3_PRO,
+                models=Inv.KH_SET,
             ),
         ],
         sources=["pv1_power", "pv2_power", "pv3_power", "pv4_power"],
+        method=sum,
+        name="PV Power",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement="kW",
+        icon="mdi:solar-power-variant-outline",
+    )
+    yield ModbusLambdaSensorDescription(
+        key="pv_power_now",
+        models=[
+            EntitySpec(
+                register_types=[RegisterType.INPUT, RegisterType.HOLDING],
+                models=Inv.H3_PRO,
+            ),
+        ],
+        sources=["pv1_power", "pv2_power", "pv3_power", "pv4_power", "pv5_power", "pv6_power"],
         method=sum,
         name="PV Power",
         device_class=SensorDeviceClass.POWER,

--- a/custom_components/foxess_modbus/entities/remote_control_description.py
+++ b/custom_components/foxess_modbus/entities/remote_control_description.py
@@ -124,7 +124,7 @@ REMOTE_CONTROL_DESCRIPTION = ModbusRemoteControlFactory(
                 invbatpower=[39238, 39237],
                 battery_soc=[37612, 38310],
                 pwr_limit_bat_up=[46019, 46018],
-                pv_voltages=[39070, 39072, 39074, 39076],
+                pv_voltages=[39070, 39072, 39074, 39076, 39078, 39080],
             ),
             models=Inv.H3_PRO,
         ),

--- a/tests/__snapshots__/test_entity_descriptions/test_entity_descriptions_for_model[Inv.H3_PRO].json
+++ b/tests/__snapshots__/test_entity_descriptions/test_entity_descriptions_for_model[Inv.H3_PRO].json
@@ -1482,7 +1482,7 @@
     "addresses": {
       "holding": [
         39286,
-        39284
+        39285
       ]
     },
     "key": "pv4_power",
@@ -1504,6 +1504,98 @@
     "type": "sensor"
   },
   {
+    "addresses": {
+      "holding": [
+        39079
+      ]
+    },
+    "key": "pv5_current",
+    "name": "PV5 Current",
+    "scale": 0.01,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "key": "pv5_energy_total",
+    "method": "left",
+    "name": "PV5 Power Total",
+    "register_types": "dict_keys(['input', 'holding'])",
+    "source": "pv5_power",
+    "type": "integration-sensor",
+    "unit_time": "h"
+  },
+  {
+    "addresses": {
+      "holding": [
+        39288,
+        39287
+      ]
+    },
+    "key": "pv5_power",
+    "name": "PV5 Power",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": {
+      "holding": [
+        39078
+      ]
+    },
+    "key": "pv5_voltage",
+    "name": "PV5 Voltage",
+    "scale": 0.1,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": {
+      "holding": [
+        39081
+      ]
+    },
+    "key": "pv6_current",
+    "name": "PV6 Current",
+    "scale": 0.01,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "key": "pv6_energy_total",
+    "method": "left",
+    "name": "PV6 Power Total",
+    "register_types": "dict_keys(['input', 'holding'])",
+    "source": "pv6_power",
+    "type": "integration-sensor",
+    "unit_time": "h"
+  },
+  {
+    "addresses": {
+      "holding": [
+        39290,
+        39289
+      ]
+    },
+    "key": "pv6_power",
+    "name": "PV6 Power",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": {
+      "holding": [
+        39080
+      ]
+    },
+    "key": "pv6_voltage",
+    "name": "PV6 Voltage",
+    "scale": 0.1,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
     "key": "pv_power_now",
     "name": "PV Power",
     "register_types": "dict_keys(['input', 'holding'])",
@@ -1511,7 +1603,9 @@
       "pv1_power",
       "pv2_power",
       "pv3_power",
-      "pv4_power"
+      "pv4_power",
+      "pv5_power",
+      "pv6_power"
     ],
     "type": "lambda"
   },


### PR DESCRIPTION
The H3-Pro provides `pv5` and `pv6` in addition to the available `pv1-4`. This PR adds the entities for `pv5` and `pv6` and amends the list of voltages for the H3-Pro.

It also correct the value of `pv4_power` which should be `39285`, based on `pv1_power`: `39279 + 2 * (4 - 1)`

I only added it for `Inv.H3_PRO`, not sure if `Inv.KH_SET` is the same.