### PR TITLE
H3: add bms cell temps and kwh remaining

### DIFF
--- a/custom_components/foxess_modbus/entities/entity_descriptions.py
+++ b/custom_components/foxess_modbus/entities/entity_descriptions.py
@@ -2131,22 +2131,27 @@ def _bms_entities() -> Iterable[EntityFactory]:
         bms_cell_temp_high=[
             ModbusAddressesSpec(input=[11043], models=Inv.H1_G1 | Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[37617], models=Inv.H1_G2_144 | Inv.KH_PRE133 | Inv.KH_133),
+            ModbusAddressesSpec(holding=[31102], models=Inv.H3_SET),
         ],
         bms_cell_temp_low=[
             ModbusAddressesSpec(input=[11044], models=Inv.H1_G1 | Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[37618], models=Inv.H1_G2_144 | Inv.KH_PRE133 | Inv.KH_133),
+            ModbusAddressesSpec(holding=[31103], models=Inv.H3_SET),
         ],
         bms_cell_mv_high=[
             ModbusAddressesSpec(input=[11045], models=Inv.H1_G1 | Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[37619], models=Inv.H1_G2_144 | Inv.KH_PRE133 | Inv.KH_133),
+            # ModbusAddressesSpec(holding=[31100], models=Inv.H3_SET), provided in V * 10 aka 32 for 3200mV
         ],
         bms_cell_mv_low=[
             ModbusAddressesSpec(input=[11046], models=Inv.H1_G1 | Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[37620], models=Inv.H1_G2_144 | Inv.KH_PRE133 | Inv.KH_133),
+            # ModbusAddressesSpec(holding=[31101], models=Inv.H3_SET), provided in V * 10 aka 32 for 3200mV
         ],
         bms_kwh_remaining=[
             ModbusAddressesSpec(input=[11037], models=Inv.H1_G1 | Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[37632], models=Inv.H1_G2_SET | Inv.KH_PRE133 | Inv.KH_133),
+            ModbusAddressesSpec(holding=[31123], models=Inv.H3_SET),
         ],
     )
     yield from _inner(

--- a/tests/__snapshots__/test_entity_descriptions/test_entity_descriptions_for_model[Inv.AIO_H3].json
+++ b/tests/__snapshots__/test_entity_descriptions/test_entity_descriptions_for_model[Inv.AIO_H3].json
@@ -148,6 +148,42 @@
   {
     "addresses": {
       "holding": [
+        31102
+      ]
+    },
+    "key": "bms_cell_temp_high",
+    "name": "BMS Cell Temp High",
+    "scale": 0.1,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": {
+      "holding": [
+        31103
+      ]
+    },
+    "key": "bms_cell_temp_low",
+    "name": "BMS Cell Temp Low",
+    "scale": 0.1,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": {
+      "holding": [
+        31123
+      ]
+    },
+    "key": "bms_kwh_remaining",
+    "name": "BMS kWh Remaining",
+    "scale": 0.01,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": {
+      "holding": [
         31025
       ]
     },

--- a/tests/__snapshots__/test_entity_descriptions/test_entity_descriptions_for_model[Inv.H3].json
+++ b/tests/__snapshots__/test_entity_descriptions/test_entity_descriptions_for_model[Inv.H3].json
@@ -148,6 +148,42 @@
   {
     "addresses": {
       "holding": [
+        31102
+      ]
+    },
+    "key": "bms_cell_temp_high",
+    "name": "BMS Cell Temp High",
+    "scale": 0.1,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": {
+      "holding": [
+        31103
+      ]
+    },
+    "key": "bms_cell_temp_low",
+    "name": "BMS Cell Temp Low",
+    "scale": 0.1,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": {
+      "holding": [
+        31123
+      ]
+    },
+    "key": "bms_kwh_remaining",
+    "name": "BMS kWh Remaining",
+    "scale": 0.01,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": {
+      "holding": [
         31025
       ]
     },

--- a/tests/__snapshots__/test_entity_descriptions/test_entity_descriptions_for_model[Inv.KUARA_H3].json
+++ b/tests/__snapshots__/test_entity_descriptions/test_entity_descriptions_for_model[Inv.KUARA_H3].json
@@ -148,6 +148,42 @@
   {
     "addresses": {
       "holding": [
+        31102
+      ]
+    },
+    "key": "bms_cell_temp_high",
+    "name": "BMS Cell Temp High",
+    "scale": 0.1,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": {
+      "holding": [
+        31103
+      ]
+    },
+    "key": "bms_cell_temp_low",
+    "name": "BMS Cell Temp Low",
+    "scale": 0.1,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": {
+      "holding": [
+        31123
+      ]
+    },
+    "key": "bms_kwh_remaining",
+    "name": "BMS kWh Remaining",
+    "scale": 0.01,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": {
+      "holding": [
         31025
       ]
     },


### PR DESCRIPTION
cell_mv_[low|high] are provided in V * 10 by the inverter which makes them unusable without refactoring.

If someone has an idea how to approach a refactor and feels like this is worth it desipite of the low value resolution of 100mv, feel free to guide me into the right direction.

Tested on H3 with
Master: 2.01
Manager: 1.80