### PR TITLE
AC1 G2 inverter profile added

### DIFF
--- a/custom_components/foxess_modbus/inverter_profiles.py
+++ b/custom_components/foxess_modbus/inverter_profiles.py
@@ -214,6 +214,15 @@ INVERTER_PROFILES = {
             ConnectionType.LAN,
             RegisterType.HOLDING,
         ),
+        # AC1-5.0-E-G2. Has to appear before AC1 G1 see https://github.com/nathanmarlor/foxess_modbus/discussions/715
+        InverterModelProfile(
+            InverterModel.AC1, r"^AC1-([\d\.]+)-E-G2", capacity_parser=CapacityParser.H1
+        ).add_connection_type(
+            Inv.H1_G2,
+            ConnectionType.AUX,
+            RegisterType.HOLDING,
+            special_registers=H1_G2_REGISTERS,
+        ),
         InverterModelProfile(InverterModel.AC1, r"^AC1-([\d\.]+)", capacity_parser=CapacityParser.H1)
         .add_connection_type(
             Inv.H1_G1,


### PR DESCRIPTION
Add AC1 G2 has same register mapping as H1 G2

see https://github.com/nathanmarlor/foxess_modbus/discussions/715