### PR TITLE
Update release-drafter to run on every commit

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,17 @@
+name: Draft a release note
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  draft_release:
+    name: Release Drafter
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run release-drafter
+        uses: release-drafter/release-drafter@v6.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ permissions:
   contents: write
 
 jobs:
-  build:
+  release:
     name: Create release
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
It looks like it needs this to keep its draft up to date. We then edit the draft with the proper version when we push a tag.