### PR TITLE
Enable modbus retries on an empty response

### DIFF
--- a/custom_components/foxess_modbus/client/modbus_client.py
+++ b/custom_components/foxess_modbus/client/modbus_client.py
@@ -55,6 +55,8 @@ _CLIENTS: dict[str, dict[str, Any]] = {
     },
 }
 
+_NUM_RETRIES = 3
+
 serial.protocol_handler_packages.append(client.__name__)
 
 
@@ -76,6 +78,9 @@ class ModbusClient:
             **config,
             "framer": client["framer"],
             "delay_on_connect": 1 if adapter.connection_type == ConnectionType.LAN else None,
+            "retries": _NUM_RETRIES,
+            # See https://github.com/nathanmarlor/foxess_modbus/discussions/792
+            "retry_on_empty": True,
         }
 
         # If our custom PosixPollSerial hack is supported, use that. This uses poll rather than select, which means we


### PR DESCRIPTION
It seems at least one user/inverter has a flakey enough connection that this is useful, see #792.