### PR TITLE
H3 Pro - scale changed for daily and total energy entities

### DIFF
--- a/custom_components/foxess_modbus/entities/entity_descriptions.py
+++ b/custom_components/foxess_modbus/entities/entity_descriptions.py
@@ -1563,13 +1563,13 @@ def _inverter_entities() -> Iterable[EntityFactory]:
             ModbusAddressesSpec(
                 holding=[32001, 32000], models=Inv.H1_G1 | Inv.H1_G2_SET | Inv.H3_SET | Inv.KH_PRE133 | Inv.KH_133
             ),
-            ModbusAddressesSpec(holding=[39602, 39601], models=Inv.H3_PRO_SET),
+            ModbusAddressesSpec(holding=[39602, 39601], models=Inv.H3_PRO_PRE122),
         ],
         scale=0.1,
     )
     yield _solar_energy_total(
         addresses=[
-            ModbusAddressesSpec(holding=[39602, 39601], models=Inv.H3_SMART),
+            ModbusAddressesSpec(holding=[39602, 39601], models=Inv.H3_SMART | Inv.H3_PRO_122),
         ],
         scale=0.01,
     )
@@ -1594,13 +1594,13 @@ def _inverter_entities() -> Iterable[EntityFactory]:
             ModbusAddressesSpec(
                 holding=[32002], models=Inv.H1_G1 | Inv.H1_G2_SET | Inv.H3_SET | Inv.KH_PRE133 | Inv.KH_133
             ),
-            ModbusAddressesSpec(holding=[39604, 39603], models=Inv.H3_PRO_SET),
+            ModbusAddressesSpec(holding=[39604, 39603], models=Inv.H3_PRO_PRE122),
         ],
         scale=0.1,
     )
     yield _solar_energy_today(
         addresses=[
-            ModbusAddressesSpec(holding=[39604, 39603], models=Inv.H3_SMART),
+            ModbusAddressesSpec(holding=[39604, 39603], models=Inv.H3_SMART | Inv.H3_PRO_122),
         ],
         scale=0.01,
     )
@@ -1625,13 +1625,13 @@ def _inverter_entities() -> Iterable[EntityFactory]:
             ModbusAddressesSpec(
                 holding=[32004, 32003], models=Inv.H1_G1 | Inv.H1_G2_SET | Inv.H3_SET | Inv.KH_PRE133 | Inv.KH_133
             ),
-            ModbusAddressesSpec(holding=[39606, 39605], models=Inv.H3_PRO_SET),
+            ModbusAddressesSpec(holding=[39606, 39605], models=Inv.H3_PRO_PRE122),
         ],
         scale=0.1,
     )
     yield _battery_charge_total(
         addresses=[
-            ModbusAddressesSpec(holding=[39606, 39605], models=Inv.H3_SMART),
+            ModbusAddressesSpec(holding=[39606, 39605], models=Inv.H3_SMART | Inv.H3_PRO_122),
         ],
         scale=0.01,
     )
@@ -1668,13 +1668,13 @@ def _inverter_entities() -> Iterable[EntityFactory]:
             ModbusAddressesSpec(input=[11074], models=Inv.H1_G1 | Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[32005], models=Inv.H1_G1 | Inv.H1_G2_SET | Inv.H3_SET),
             ModbusAddressesSpec(holding=[32005], models=Inv.KH_PRE133 | Inv.KH_133),
-            ModbusAddressesSpec(holding=[39608, 39607], models=Inv.H3_PRO_SET),
+            ModbusAddressesSpec(holding=[39608, 39607], models=Inv.H3_PRO_PRE122),
         ],
         scale=0.1,
     )
     yield _battery_charge_today(
         addresses=[
-            ModbusAddressesSpec(holding=[39608, 39607], models=Inv.H3_SMART),
+            ModbusAddressesSpec(holding=[39608, 39607], models=Inv.H3_SMART | Inv.H3_PRO_122),
         ],
         scale=0.01,
     )
@@ -1699,13 +1699,13 @@ def _inverter_entities() -> Iterable[EntityFactory]:
             ModbusAddressesSpec(
                 holding=[32007, 32006], models=Inv.H1_G1 | Inv.H1_G2_SET | Inv.H3_SET | Inv.KH_PRE133 | Inv.KH_133
             ),
-            ModbusAddressesSpec(holding=[39610, 39609], models=Inv.H3_PRO_SET),
+            ModbusAddressesSpec(holding=[39610, 39609], models=Inv.H3_PRO_PRE122),
         ],
         scale=0.1,
     )
     yield _battery_discharge_total(
         addresses=[
-            ModbusAddressesSpec(holding=[39610, 39609], models=Inv.H3_SMART),
+            ModbusAddressesSpec(holding=[39610, 39609], models=Inv.H3_SMART | Inv.H3_PRO_122),
         ],
         scale=0.01,
     )
@@ -1743,14 +1743,14 @@ def _inverter_entities() -> Iterable[EntityFactory]:
             ModbusAddressesSpec(
                 holding=[32008], models=Inv.H1_G1 | Inv.H1_G2_SET | Inv.H3_SET | Inv.KH_PRE133 | Inv.KH_133
             ),
-            ModbusAddressesSpec(holding=[39612, 39611], models=Inv.H3_PRO_SET),
+            ModbusAddressesSpec(holding=[39612, 39611], models=Inv.H3_PRO_PRE122),
         ],
         scale=0.1,
     )
 
     yield _battery_discharge_today(
         addresses=[
-            ModbusAddressesSpec(holding=[39612, 39611], models=Inv.H3_SMART),
+            ModbusAddressesSpec(holding=[39612, 39611], models=Inv.H3_SMART | Inv.H3_PRO_122),
         ],
         scale=0.01,
     )
@@ -1775,14 +1775,14 @@ def _inverter_entities() -> Iterable[EntityFactory]:
             ModbusAddressesSpec(
                 holding=[32010, 32009], models=Inv.H1_G1 | Inv.H1_G2_SET | Inv.H3_SET | Inv.KH_PRE133 | Inv.KH_133
             ),
-            ModbusAddressesSpec(holding=[39614, 39613], models=Inv.H3_PRO_SET),
+            ModbusAddressesSpec(holding=[39614, 39613], models=Inv.H3_PRO_PRE122),
         ],
         scale=0.1,
     )
 
     yield _feed_in_energy_total(
         addresses=[
-            ModbusAddressesSpec(holding=[39614, 39613], models=Inv.H3_SMART),
+            ModbusAddressesSpec(holding=[39614, 39613], models=Inv.H3_SMART | Inv.H3_PRO_122),
         ],
         scale=0.01,
     )
@@ -1820,14 +1820,14 @@ def _inverter_entities() -> Iterable[EntityFactory]:
             ModbusAddressesSpec(
                 holding=[32011], models=Inv.H1_G1 | Inv.H1_G2_SET | Inv.H3_SET | Inv.KH_PRE133 | Inv.KH_133
             ),
-            ModbusAddressesSpec(holding=[39616, 39615], models=Inv.H3_PRO_SET),
+            ModbusAddressesSpec(holding=[39616, 39615], models=Inv.H3_PRO_PRE122),
         ],
         scale=0.1,
     )
 
     yield _feed_in_energy_today(
         addresses=[
-            ModbusAddressesSpec(holding=[39616, 39615], models=Inv.H3_SMART),
+            ModbusAddressesSpec(holding=[39616, 39615], models=Inv.H3_SMART | Inv.H3_PRO_122),
         ],
         scale=0.01,
     )
@@ -1852,14 +1852,14 @@ def _inverter_entities() -> Iterable[EntityFactory]:
             ModbusAddressesSpec(
                 holding=[32013, 32012], models=Inv.H1_G1 | Inv.H1_G2_SET | Inv.H3_SET | Inv.KH_PRE133 | Inv.KH_133
             ),
-            ModbusAddressesSpec(holding=[39618, 39617], models=Inv.H3_PRO_SET),
+            ModbusAddressesSpec(holding=[39618, 39617], models=Inv.H3_PRO_PRE122),
         ],
         scale=0.1,
     )
 
     yield _grid_consumption_energy_total(
         addresses=[
-            ModbusAddressesSpec(holding=[39618, 39617], models=Inv.H3_SMART),
+            ModbusAddressesSpec(holding=[39618, 39617], models=Inv.H3_SMART | Inv.H3_PRO_122),
         ],
         scale=0.01,
     )
@@ -1897,14 +1897,14 @@ def _inverter_entities() -> Iterable[EntityFactory]:
             ModbusAddressesSpec(
                 holding=[32014], models=Inv.H1_G1 | Inv.H1_G2_SET | Inv.H3_SET | Inv.KH_PRE133 | Inv.KH_133
             ),
-            ModbusAddressesSpec(holding=[39620, 39619], models=Inv.H3_PRO_SET),
+            ModbusAddressesSpec(holding=[39620, 39619], models=Inv.H3_PRO_PRE122),
         ],
         scale=0.1,
     )
 
     yield _grid_consumption_energy_today(
         addresses=[
-            ModbusAddressesSpec(holding=[39620, 39619], models=Inv.H3_SMART),
+            ModbusAddressesSpec(holding=[39620, 39619], models=Inv.H3_SMART | Inv.H3_PRO_122),
         ],
         scale=0.01,
     )
@@ -1929,14 +1929,14 @@ def _inverter_entities() -> Iterable[EntityFactory]:
             ModbusAddressesSpec(
                 holding=[32016, 32015], models=Inv.H1_G1 | Inv.H1_G2_SET | Inv.H3_SET | Inv.KH_PRE133 | Inv.KH_133
             ),
-            ModbusAddressesSpec(holding=[39622, 39621], models=Inv.H3_PRO_SET),
+            ModbusAddressesSpec(holding=[39622, 39621], models=Inv.H3_PRO_PRE122),
         ],
         scale=0.1,
     )
 
     yield _total_yield_total(
         addresses=[
-            ModbusAddressesSpec(holding=[39622, 39621], models=Inv.H3_SMART),
+            ModbusAddressesSpec(holding=[39622, 39621], models=Inv.H3_SMART | Inv.H3_PRO_122),
         ],
         scale=0.01,
     )
@@ -1961,14 +1961,14 @@ def _inverter_entities() -> Iterable[EntityFactory]:
             ModbusAddressesSpec(
                 holding=[32017], models=Inv.H1_G1 | Inv.H1_G2_SET | Inv.H3_SET | Inv.KH_PRE133 | Inv.KH_133
             ),
-            ModbusAddressesSpec(holding=[39624, 39623], models=Inv.H3_PRO_SET),
+            ModbusAddressesSpec(holding=[39624, 39623], models=Inv.H3_PRO_PRE122),
         ],
         scale=0.1,
     )
 
     yield _total_yield_today(
         addresses=[
-            ModbusAddressesSpec(holding=[39624, 39623], models=Inv.H3_SMART),
+            ModbusAddressesSpec(holding=[39624, 39623], models=Inv.H3_SMART | Inv.H3_PRO_122),
         ],
         scale=0.01,
     )
@@ -1993,14 +1993,14 @@ def _inverter_entities() -> Iterable[EntityFactory]:
             ModbusAddressesSpec(
                 holding=[32019, 32018], models=Inv.H1_G1 | Inv.H1_G2_SET | Inv.H3_SET | Inv.KH_PRE133 | Inv.KH_133
             ),
-            ModbusAddressesSpec(holding=[39626, 39625], models=Inv.H3_PRO_SET),
+            ModbusAddressesSpec(holding=[39626, 39625], models=Inv.H3_PRO_PRE122),
         ],
         scale=0.1,
     )
 
     yield _input_energy_total(
         addresses=[
-            ModbusAddressesSpec(holding=[39626, 39625], models=Inv.H3_SMART),
+            ModbusAddressesSpec(holding=[39626, 39625], models=Inv.H3_SMART | Inv.H3_PRO_122),
         ],
         scale=0.01,
     )
@@ -2025,14 +2025,14 @@ def _inverter_entities() -> Iterable[EntityFactory]:
             ModbusAddressesSpec(
                 holding=[32020], models=Inv.H1_G1 | Inv.H1_G2_SET | Inv.H3_SET | Inv.KH_PRE133 | Inv.KH_133
             ),
-            ModbusAddressesSpec(holding=[39628, 39627], models=Inv.H3_PRO_SET),
+            ModbusAddressesSpec(holding=[39628, 39627], models=Inv.H3_PRO_PRE122),
         ],
         scale=0.1,
     )
 
     yield _input_energy_today(
         addresses=[
-            ModbusAddressesSpec(holding=[39628, 39627], models=Inv.H3_SMART),
+            ModbusAddressesSpec(holding=[39628, 39627], models=Inv.H3_SMART | Inv.H3_PRO_122),
         ],
         scale=0.01,
     )
@@ -2059,14 +2059,14 @@ def _inverter_entities() -> Iterable[EntityFactory]:
             # ),
             ModbusAddressesSpec(input=[11091, 11090], models=Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[32022, 32021], models=Inv.KH_PRE133 | Inv.KH_133 | Inv.H1_G2_SET | Inv.H3_SET),
-            ModbusAddressesSpec(holding=[39630, 39629], models=Inv.H3_PRO_SET),
+            ModbusAddressesSpec(holding=[39630, 39629], models=Inv.H3_PRO_PRE122),
         ],
         scale=0.1,
     )
 
     yield _load_power_total(
         addresses=[
-            ModbusAddressesSpec(holding=[39630, 39629], models=Inv.H3_SMART),
+            ModbusAddressesSpec(holding=[39630, 39629], models=Inv.H3_SMART | Inv.H3_PRO_122),
         ],
         scale=0.01,
     )
@@ -2108,14 +2108,14 @@ def _inverter_entities() -> Iterable[EntityFactory]:
             ModbusAddressesSpec(
                 holding=[32023], models=Inv.H1_G1 | Inv.H1_G2_SET | Inv.H3_SET | Inv.KH_PRE133 | Inv.KH_133
             ),
-            ModbusAddressesSpec(holding=[39632, 39631], models=Inv.H3_PRO_SET),
+            ModbusAddressesSpec(holding=[39632, 39631], models=Inv.H3_PRO_PRE122),
         ],
         scale=0.1,
     )
 
     yield _load_energy_today(
         addresses=[
-            ModbusAddressesSpec(holding=[39632, 39631], models=Inv.H3_SMART),
+            ModbusAddressesSpec(holding=[39632, 39631], models=Inv.H3_SMART | Inv.H3_PRO_122),
         ],
         scale=0.01,
     )


### PR DESCRIPTION
Fixes #724

Later versions of H3 Pro firmware use a scale of 0.01 for the daily and running total energy values (e.g. `solar_energy_total`) instead of 0.1.

This appears to match the behaviour of H3 Smart model.

I have assumed the changes became effective as of firmware dev release 1.22, this seems likely and a model profile already exists for post-1.22 versions so re-using that simplifies the fix. We know from #724 that it appeared in 1.25 at the latest, and remains in versions 1.33 and 1.34.

It works for me but I don't want to break it for anyone on a previous firmware version, so I would like someone on 1.22 to confirm if the scale is off on theirs too. If  not then it must have been changed _after_ 1.22 - in that case I'll change it so it applies  from 1.25...