### PR TITLE
H3_180: use proper cell mv registers

### DIFF
--- a/custom_components/foxess_modbus/entities/entity_descriptions.py
+++ b/custom_components/foxess_modbus/entities/entity_descriptions.py
@@ -2299,12 +2299,12 @@ def _bms_entities() -> Iterable[EntityFactory]:
         bms_cell_mv_high=[
             ModbusAddressesSpec(input=[11045], models=Inv.H1_G1 | Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[37619], models=Inv.H1_G2_144 | Inv.KH_133),
-            ModbusAddressesSpec(holding=[31100], models=Inv.H3_180),
+            ModbusAddressesSpec(holding=[31134], models=Inv.H3_180),
         ],
         bms_cell_mv_low=[
             ModbusAddressesSpec(input=[11046], models=Inv.H1_G1 | Inv.KH_PRE119),
             ModbusAddressesSpec(holding=[37620], models=Inv.H1_G2_144 | Inv.KH_133),
-            ModbusAddressesSpec(holding=[31101], models=Inv.H3_180),
+            ModbusAddressesSpec(holding=[31135], models=Inv.H3_180),
         ],
         bms_kwh_remaining=[
             ModbusAddressesSpec(input=[11037], models=Inv.H1_G1 | Inv.KH_PRE119),

--- a/tests/__snapshots__/test_entity_descriptions/test_entities[AC3-AUX-latest].json
+++ b/tests/__snapshots__/test_entity_descriptions/test_entities[AC3-AUX-latest].json
@@ -123,7 +123,7 @@
   },
   {
     "addresses": [
-      31100
+      31134
     ],
     "key": "bms_cell_mv_high",
     "name": "BMS Cell mV High",
@@ -133,7 +133,7 @@
   },
   {
     "addresses": [
-      31101
+      31135
     ],
     "key": "bms_cell_mv_low",
     "name": "BMS Cell mV Low",

--- a/tests/__snapshots__/test_entity_descriptions/test_entities[H3-AUX-latest].json
+++ b/tests/__snapshots__/test_entity_descriptions/test_entities[H3-AUX-latest].json
@@ -123,7 +123,7 @@
   },
   {
     "addresses": [
-      31100
+      31134
     ],
     "key": "bms_cell_mv_high",
     "name": "BMS Cell mV High",
@@ -133,7 +133,7 @@
   },
   {
     "addresses": [
-      31101
+      31135
     ],
     "key": "bms_cell_mv_low",
     "name": "BMS Cell mV Low",


### PR DESCRIPTION
Somehow I overlooked that these registers exist. Found them while scanning for new stuff in 1.87. They are in mV! I also found the export limit but that's probably known already.

Version is: 1.87, can someone verify they exist on 1.80?