### PR TITLE
Adding support for P1 Inverters

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Supported models:
 - FoxESS H1 (including AC1, AIO-H1 and G2)
 - FoxESS H3 (including AC3 and AOI-H3)
 - FoxESS H3 PRO
+- FoxESS P1
 - FoxESS KH
 - Kuara H3
 - Sonnenkraft SK-HWR

--- a/custom_components/foxess_modbus/common/types.py
+++ b/custom_components/foxess_modbus/common/types.py
@@ -37,6 +37,7 @@ class InverterModel(StrEnum):
 
     H1_G1 = "H1"  # Can't change the value, as it's set in people's configs
     H1_G2 = "H1_G2"
+    P1 = "H1"
 
     AC1 = "AC1"
     AC1_G2 = "AC1_G2"

--- a/custom_components/foxess_modbus/common/types.py
+++ b/custom_components/foxess_modbus/common/types.py
@@ -37,7 +37,8 @@ class InverterModel(StrEnum):
 
     H1_G1 = "H1"  # Can't change the value, as it's set in people's configs
     H1_G2 = "H1_G2"
-    P1 = "H1"
+
+    P1 = "P1"
 
     AC1 = "AC1"
     AC1_G2 = "AC1_G2"

--- a/custom_components/foxess_modbus/inverter_profiles.py
+++ b/custom_components/foxess_modbus/inverter_profiles.py
@@ -296,6 +296,14 @@ _INVERTER_PROFILES_LIST = [
         versions={Version(1, 44): Inv.H1_G2_PRE144, None: Inv.H1_G2_144},
         special_registers=H1_G2_REGISTERS,
     ),
+     InverterModelProfile(
+        InverterModel.P1, r"^P1-([\d\.]+)-E", capacity_parser=CapacityParser.H1
+    ).add_connection_type(
+        ConnectionType.AUX,
+        RegisterType.HOLDING,
+        versions={Version(1, 44): Inv.H1_G2_PRE144, None: Inv.H1_G2_144},
+        special_registers=H1_G2_REGISTERS,
+    ),
     InverterModelProfile(InverterModel.AC1, r"^AC1-([\d\.]+)", capacity_parser=CapacityParser.H1)
     .add_connection_type(
         ConnectionType.AUX,


### PR DESCRIPTION
Was trying to integrate my P1 Inverter and found that there was a discussion already where a user confirmed it was the same as H1-G2 so I somewhat copied this PR: https://github.com/nathanmarlor/foxess_modbus/pull/730/files, tested on my instance and worked.

Resolves: https://github.com/nathanmarlor/foxess_modbus/discussions/914
