### PR TITLE
Add Export Limit control for KH inverters

### DIFF
--- a/custom_components/foxess_modbus/common/entity_controller.py
+++ b/custom_components/foxess_modbus/common/entity_controller.py
@@ -80,6 +80,17 @@ class EntityRemoteControlManager(ABC):
     def max_soc(self, value: int | None) -> None:
         """Set a value to override the max_soc register, if any"""
 
+    @property
+    @abstractmethod
+    def export_limit(self) -> int | None:
+        """Get the current export limit"""
+
+    @export_limit.setter
+    @abstractmethod
+    def export_limit(self, value: int | None) -> None:
+        """Set the export limit"""
+
+
 
 class EntityController(ABC):
     """Interface given to entities to access the ModbusController"""

--- a/custom_components/foxess_modbus/entities/modbus_remote_control_config.py
+++ b/custom_components/foxess_modbus/entities/modbus_remote_control_config.py
@@ -179,7 +179,28 @@ class ModbusRemoteControlFactory:
             value_setter=_set_max_soc,
         )
 
+        def _set_export_limit(manager: EntityRemoteControlManager, value: int) -> None:
+            manager.export_limit = value
+
+        # Export limit only for KH models
+        kh_models = [x.get_all_models() for x in self.address_specs if x.models & Inv.KH_SET]
+        export_limit = ModbusRemoteControlNumberDescription(
+            key="export_limit",
+            name="Export Limit",
+            models=kh_models if kh_models else [],  # Only KH models
+            native_max_value_callback=lambda x: x.inverter_capacity,  # Use inverter capacity
+            mode=NumberMode.BOX,
+            device_class=NumberDeviceClass.POWER,
+            native_min_value=0.0,
+            # Max value is read from the inverter
+            native_step=0.001,
+            native_unit_of_measurement="kW",
+            scale=0.001,
+            value_setter=_set_export_limit,
+        )
+
         self.entity_descriptions: list[EntityFactory] = [
+            export_limit,
             charge_power,
             discharge_power,
             remote_control_select,

--- a/custom_components/foxess_modbus/remote_control_manager.py
+++ b/custom_components/foxess_modbus/remote_control_manager.py
@@ -28,6 +28,7 @@ class RemoteControlManager(EntityRemoteControlManager, ModbusControllerEntity):
         self._discharge_power: int | None = None
         self._charge_power: int | None = None
         self._max_soc_override: int | None = None
+        self._export_limit: int | None = None
 
         modbus_addresses = [
             *self._addresses.battery_soc,
@@ -73,6 +74,21 @@ class RemoteControlManager(EntityRemoteControlManager, ModbusControllerEntity):
     @max_soc.setter
     def max_soc(self, value: int | None) -> None:
         self._max_soc_override = value
+
+    @property
+    def export_limit(self) -> int | None:
+        return self._export_limit
+
+    @export_limit.setter
+    def export_limit(self, value: int | None) -> None:
+        self._export_limit = value
+        # Export limit writes to register 41012 (H1, H3, KH series) or 46616 (other models)
+        if value is not None:
+            # Schedule the async write operation using Home Assistant's event loop
+            self._controller.hass.async_create_task(
+                self._controller.write_register(41012, value)
+            )
+
 
     async def _update(self) -> None:
         if not self._controller.is_connected:


### PR DESCRIPTION
- Add export_limit property to EntityRemoteControlManager interface
- Implement export_limit setter in RemoteControlManager with async register write
- Add ModbusRemoteControlNumberDescription for export limit in remote control config
- Restrict export limit to KH models only (KH_PRE119, KH_PRE133, KH_133)
- Use register 41012 for KH inverters
- Support 0-10kW range with 0.001kW steps
- Integrate with existing remote control system