### PR TITLE
Lowercase phase suffixes in entity keys to please HA 2026.2 stricter requirements

### DIFF
--- a/custom_components/foxess_modbus/entities/entity_descriptions.py
+++ b/custom_components/foxess_modbus/entities/entity_descriptions.py
@@ -773,7 +773,7 @@ def _h1_current_voltage_power_entities() -> Iterable[EntityFactory]:
 def _h3_current_voltage_power_entities() -> Iterable[EntityFactory]:
     def _grid_voltage(phase: str, addresses: list[ModbusAddressesSpec]) -> EntityFactory:
         return ModbusSensorDescription(
-            key=f"grid_voltage_{phase}",
+            key=f"grid_voltage_{phase.lower()}",
             addresses=addresses,
             entity_registry_enabled_default=False,
             name=f"Grid Voltage {phase}",
@@ -810,7 +810,7 @@ def _h3_current_voltage_power_entities() -> Iterable[EntityFactory]:
 
     def _inv_current(phase: str, addresses: list[ModbusAddressesSpec], scale: float) -> EntityFactory:
         return ModbusSensorDescription(
-            key=f"inv_current_{phase}",
+            key=f"inv_current_{phase.lower()}",
             addresses=addresses,
             name=f"Inverter Current {phase}",
             device_class=SensorDeviceClass.CURRENT,
@@ -846,7 +846,7 @@ def _h3_current_voltage_power_entities() -> Iterable[EntityFactory]:
     )
 
     def _inv_power(phase: str | None, addresses: list[ModbusAddressesSpec], scale: float) -> EntityFactory:
-        key_suffix = f"_{phase}" if phase is not None else ""
+        key_suffix = f"_{phase.lower()}" if phase is not None else ""
         name_suffix = f" {phase}" if phase is not None else ""
         return ModbusSensorDescription(
             key=f"inv_power{key_suffix}",
@@ -894,7 +894,7 @@ def _h3_current_voltage_power_entities() -> Iterable[EntityFactory]:
     )
 
     def _inv_power_reactive(phase: str | None, addresses: list[ModbusAddressesSpec]) -> EntityFactory:
-        key_suffix = f"_{phase}" if phase is not None else ""
+        key_suffix = f"_{phase.lower()}" if phase is not None else ""
         name_suffix = f" {phase}" if phase is not None else ""
         return ModbusSensorDescription(
             key=f"inv_power_Q{key_suffix}",
@@ -926,7 +926,7 @@ def _h3_current_voltage_power_entities() -> Iterable[EntityFactory]:
     )
 
     def _inv_power_apparent(phase: str | None, addresses: list[ModbusAddressesSpec]) -> EntityFactory:
-        key_suffix = f"_{phase}" if phase is not None else ""
+        key_suffix = f"_{phase.lower()}" if phase is not None else ""
         name_suffix = f" {phase}" if phase is not None else ""
         return ModbusSensorDescription(
             key=f"rpower_S{key_suffix}",
@@ -956,7 +956,7 @@ def _h3_current_voltage_power_entities() -> Iterable[EntityFactory]:
 
     def _eps_rvolt(phase: str, addresses: list[ModbusAddressesSpec]) -> EntityFactory:
         return ModbusSensorDescription(
-            key=f"eps_rvolt_{phase}",
+            key=f"eps_rvolt_{phase.lower()}",
             addresses=addresses,
             entity_registry_enabled_default=False,
             name=f"EPS Voltage_{phase}",
@@ -975,7 +975,7 @@ def _h3_current_voltage_power_entities() -> Iterable[EntityFactory]:
 
     def _eps_rcurrent(phase: str, addresses: list[ModbusAddressesSpec]) -> EntityFactory:
         return ModbusSensorDescription(
-            key=f"eps_rcurrent_{phase}",
+            key=f"eps_rcurrent_{phase.lower()}",
             addresses=addresses,
             entity_registry_enabled_default=False,
             name=f"EPS Current {phase}",
@@ -999,7 +999,7 @@ def _h3_current_voltage_power_entities() -> Iterable[EntityFactory]:
 
     def _eps_power(phase: str, addresses: list[ModbusAddressesSpec]) -> EntityFactory:
         return ModbusSensorDescription(
-            key=f"eps_power_{phase}",
+            key=f"eps_power_{phase.lower()}",
             addresses=addresses,
             entity_registry_enabled_default=False,
             name=f"EPS Power {phase}",
@@ -1035,7 +1035,7 @@ def _h3_current_voltage_power_entities() -> Iterable[EntityFactory]:
     )
 
     def _grid_ct(phase: str | None, scale: float, addresses: list[ModbusAddressesSpec]) -> Iterable[EntityFactory]:
-        key_suffix = f"_{phase}" if phase is not None else ""
+        key_suffix = f"_{phase.lower()}" if phase is not None else ""
         name_suffix = f" {phase}" if phase is not None else ""
 
         yield ModbusSensorDescription(
@@ -1128,7 +1128,7 @@ def _h3_current_voltage_power_entities() -> Iterable[EntityFactory]:
     )
 
     def _grid_ct_reactive(phase: str | None, scale: float, addresses: list[ModbusAddressesSpec]) -> EntityFactory:
-        key_suffix = f"_{phase}" if phase is not None else ""
+        key_suffix = f"_{phase.lower()}" if phase is not None else ""
         name_suffix = f" {phase}" if phase is not None else ""
 
         return ModbusSensorDescription(
@@ -1167,7 +1167,7 @@ def _h3_current_voltage_power_entities() -> Iterable[EntityFactory]:
     )
 
     def _grid_ct_apparent(phase: str | None, scale: float, addresses: list[ModbusAddressesSpec]) -> EntityFactory:
-        key_suffix = f"_{phase}" if phase is not None else ""
+        key_suffix = f"_{phase.lower()}" if phase is not None else ""
         name_suffix = f" {phase}" if phase is not None else ""
 
         return ModbusSensorDescription(
@@ -1206,7 +1206,7 @@ def _h3_current_voltage_power_entities() -> Iterable[EntityFactory]:
     )
 
     def _grid_ct_power_factor(phase: str | None, scale: float, addresses: list[ModbusAddressesSpec]) -> EntityFactory:
-        key_suffix = f"_{phase}" if phase is not None else ""
+        key_suffix = f"_{phase.lower()}" if phase is not None else ""
         name_suffix = f" {phase}" if phase is not None else ""
 
         return ModbusSensorDescription(
@@ -1244,7 +1244,7 @@ def _h3_current_voltage_power_entities() -> Iterable[EntityFactory]:
     )
 
     def _ct2_meter(phase: str | None, scale: float, addresses: list[ModbusAddressesSpec]) -> ModbusSensorDescription:
-        key_suffix = f"_{phase}" if phase is not None else ""
+        key_suffix = f"_{phase.lower()}" if phase is not None else ""
         name_suffix = f" {phase}" if phase is not None else ""
 
         return ModbusSensorDescription(
@@ -1276,7 +1276,7 @@ def _h3_current_voltage_power_entities() -> Iterable[EntityFactory]:
     )
 
     def _load_power(phase: str | None, *, addresses: list[ModbusAddressesSpec]) -> EntityFactory:
-        key_suffix = f"_{phase}" if phase is not None else ""
+        key_suffix = f"_{phase.lower()}" if phase is not None else ""
         name_suffix = f" {phase}" if phase is not None else ""
         return ModbusSensorDescription(
             key=f"load_power{key_suffix}",


### PR DESCRIPTION
FYI - This is bad. Do not use.
Renaming entities to fix upper/lower case means History is gone, as HA re-adds them as new entities with _2 suffix. Refer to my other pull request 1030