### PR TITLE
Slugify entity_id generation without changing keys / loosing history

### DIFF
--- a/custom_components/foxess_modbus/entities/modbus_entity_mixin.py
+++ b/custom_components/foxess_modbus/entities/modbus_entity_mixin.py
@@ -7,6 +7,7 @@ from typing import Protocol
 from typing import cast
 
 from homeassistant.const import Platform
+from homeassistant.util import slugify
 from homeassistant.helpers import entity_registry
 from homeassistant.helpers.entity import ABCCachedProperties
 from homeassistant.helpers.entity import DeviceInfo
@@ -51,7 +52,7 @@ def _add_entity_id_prefix(key: str, inv_details: dict[str, Any]) -> str:
     if entity_id_prefix:
         key = f"{entity_id_prefix}_{key}"
 
-    return key
+    return slugify(key, separator="_")
 
 
 def _create_unique_id(key: str, inv_details: dict[str, Any]) -> str:


### PR DESCRIPTION
This is a fix for issue here https://github.com/nathanmarlor/foxess_modbus/issues/1028

There are a number of entities keys that have uppercase which HA 2026.2 disallows now.

This fixes the issue and existing entities maintain history.
Tested it via a release on my git here - https://github.com/DanielNagy/foxess_modbus/releases


