### PR TITLE
fix: use abs() for battery charge power registers on H3-Smart inverters

### DIFF
--- a/custom_components/foxess_modbus/remote_control_manager.py
+++ b/custom_components/foxess_modbus/remote_control_manager.py
@@ -195,8 +195,8 @@ class RemoteControlManager(EntityRemoteControlManager, ModbusControllerEntity):
             await self._write_active_power(-max_import_power)
             return
 
-        max_battery_charge_power = -max_battery_charge_power_negative
-        current_battery_charge_power = -current_battery_charge_power_negative
+        max_battery_charge_power = abs(max_battery_charge_power_negative)
+        current_battery_charge_power = abs(current_battery_charge_power_negative)
 
         # If the BMS has decided not to charge the battery (which it might do if it's almost full), then don't try and
         # be clever.


### PR DESCRIPTION
## Problem

The `pwr_limit_bat_up` registers (`[46019, 46018]`) return **positive** values on FoxESS H3-Smart inverters, but the code in `remote_control_manager.py` unconditionally negates them:

```python
max_battery_charge_power = -max_battery_charge_power_negative
current_battery_charge_power = -current_battery_charge_power_negative
```

On H1 inverters, these registers return negative values (e.g. `-9999`), so negation correctly produces `+9999W`.

On **H3-Smart**, the same registers return **positive** values (e.g. `+9999`), so negation produces `-9999W`.

This causes the BMS protection check (`if max_battery_charge_power < 50`) to trigger every cycle, which disables `RemoteControlManager` silently. The result: **Force Charge appears to be set in Home Assistant but the inverter never actually charges from the grid.**

## Fix

Replace negation with `abs()` to handle both sign conventions without model-specific branching:

```python
max_battery_charge_power = abs(max_battery_charge_power_negative)
current_battery_charge_power = abs(current_battery_charge_power_negative)
```

## Testing

Tested on FoxESS **H3-10.0-Smart** (`H3_SMART`):
- Before fix: battery power 0.0 kW despite Force Charge mode active
- After fix: battery charging confirmed at **-6.4 kW / 15.7 A** from grid ✅

H1 inverters are unaffected: `abs(-9999) = 9999`, same as before.

## Related

- Registers `[46019, 46018]` = `pwr_limit_bat_up` (32-bit, max battery charge power)
- Inverter model: `H3_SMART` in foxess_modbus config
