### PR TITLE
fix: prevent re-entrant calls in RemoteControlManager callbacks

### DIFF
--- a/custom_components/foxess_modbus/remote_control_manager.py
+++ b/custom_components/foxess_modbus/remote_control_manager.py
@@ -28,6 +28,7 @@ class RemoteControlManager(EntityRemoteControlManager, ModbusControllerEntity):
         self._discharge_power: int | None = None
         self._charge_power: int | None = None
         self._max_soc_override: int | None = None
+        self._is_updating = False
 
         modbus_addresses = [
             *self._addresses.battery_soc,
@@ -321,11 +322,23 @@ class RemoteControlManager(EntityRemoteControlManager, ModbusControllerEntity):
         return self._modbus_addresses
 
     async def poll_complete_callback(self) -> None:
-        await self._update()
+        if self._is_updating:
+            return
+        self._is_updating = True
+        try:
+            await self._update()
+        finally:
+            self._is_updating = False
 
     async def became_connected_callback(self) -> None:
         self._remote_control_enabled = False
-        await self._update()
+        if self._is_updating:
+            return
+        self._is_updating = True
+        try:
+            await self._update()
+        finally:
+            self._is_updating = False
 
     def update_callback(self, changed_addresses: set[int]) -> None:
         pass


### PR DESCRIPTION
## Bug

`poll_complete_callback` and `became_connected_callback` both call `_update()` with no re-entrancy guard. When Force Charge is active alongside concurrent EV charging, a Modbus write completing inside `_update_charge()` can trigger another poll cycle before the first `_update()` returns. This fires `poll_complete_callback()` again while `_update()` is still on the call stack, producing infinite recursion that crashes or deadlocks the remote control manager — leaving the inverter in an undefined state (typically defaulting to Back-Up mode and ignoring active power setpoints).

Observed call stack from HA log:
```
poll_complete_callback (line 326)
  → _update (line 87)
    → _update_discharge (line 272)
      → _write_active_power (line 121)
        → poll_complete_callback   ← re-entrant
          → _update
            → ... (repeating)
```

**Symptom:** Force Charge mode active, but inverter stops importing from grid and only uses solar surplus. Battery charges at ~2kW instead of the configured maximum. Work mode entity shows "Force Charge" but inverter ignores it. Recovery requires HA restart.

**Reproduction conditions:**
- H3-Smart inverter with foxess_modbus remote control enabled
- Force Charge active
- Concurrent EV charging (adds load and frequent state updates)
- Automation writing `number.home_min_soc_on_grid` every ~5 minutes

## Fix

Add an `_is_updating` boolean flag to `RemoteControlManager.__init__`. Both `poll_complete_callback` and `became_connected_callback` check this flag before proceeding and return early if a call is already in progress. The flag is set/cleared with a `try/finally` to ensure it is always released even if `_update()` raises.

```python
async def poll_complete_callback(self) -> None:
    if self._is_updating:
        return
    self._is_updating = True
    try:
        await self._update()
    finally:
        self._is_updating = False

async def became_connected_callback(self) -> None:
    self._remote_control_enabled = False
    if self._is_updating:
        return
    self._is_updating = True
    try:
        await self._update()
    finally:
        self._is_updating = False
```

## Impact
- Affects H3-Smart (and potentially other models) with remote control + Force Charge
- Triggered by concurrent EV charging + frequent Modbus writes
- No behaviour change under normal (non-re-entrant) conditions