### PR TITLE
Fix detection of H3-12.0-E (firmware 2.23 adds -E suffix)

### DIFF
--- a/custom_components/foxess_modbus/inverter_profiles.py
+++ b/custom_components/foxess_modbus/inverter_profiles.py
@@ -346,7 +346,7 @@ _INVERTER_PROFILES_LIST = [
         special_registers=H3_SMART_REGISTERS,
     ),
     # The H3 seems to use holding registers for everything
-    InverterModelProfile(InverterModel.H3, r"^H3-([\d\.]+)").add_connection_type(
+    InverterModelProfile(InverterModel.H3, r"^H3-([\d\.]+)(?:-E)?").add_connection_type(
         ConnectionType.AUX,
         RegisterType.HOLDING,
         versions={Version(1, 80): Inv.H3_PRE180, None: Inv.H3_180},


### PR DESCRIPTION
Firmware 2.23 for H3 inverters started reporting model strings like "H3-12.0-E".
The existing regex ^H3-([\d\.]+) does not match this format, causing model
detection to fail and the integration to fall back to the serial number string.

This patch extends the regex to accept the optional "-E" suffix:

    ^H3-([\d\.]+)(?:-E)?

This change is backward‑compatible and does not affect older firmware versions.
