### PR TITLE
Add Ebyte NA111 series as a supported network adapter

### DIFF
--- a/custom_components/foxess_modbus/inverter_adapters.py
+++ b/custom_components/foxess_modbus/inverter_adapters.py
@@ -189,7 +189,7 @@ ADAPTERS = {
             config=_DefaultConfig(max_read=100),
         ),
         InverterAdapter.network(
-            "ebyte_na111_e",
+            "ebyte_na111_series",
             "https://www.cdebyte.com/products/NA111-E",
             network_protocols=[TCP, UDP],
             config=_DefaultConfig(max_read=100),

--- a/custom_components/foxess_modbus/inverter_adapters.py
+++ b/custom_components/foxess_modbus/inverter_adapters.py
@@ -189,6 +189,12 @@ ADAPTERS = {
             config=_DefaultConfig(max_read=100),
         ),
         InverterAdapter.network(
+            "ebyte_na111_e",
+            "https://www.cdebyte.com/products/NA111-E",
+            network_protocols=[TCP, UDP],
+            config=_DefaultConfig(max_read=100),
+        ),
+        InverterAdapter.network(
             "network_other",
             "https://github.com/nathanmarlor/foxess_modbus/wiki/Other-Ethernet-Adapter",
             network_protocols=[TCP, UDP, RTU_OVER_TCP],

--- a/custom_components/foxess_modbus/translations/en.json
+++ b/custom_components/foxess_modbus/translations/en.json
@@ -197,7 +197,7 @@
         "usr_tcp232_410s": "USR-TCP232-410s",
         "usr_w610": "USR-W610",
         "waveshare_rs485_to_eth_b": "Waveshare Modbus RTU Relay",
-        "ebyte_na111_e": "Ebyte NA111-E",
+        "ebyte_na111_series": "Ebyte NA111 series (NA111 / -A / -E / -M)",
         "network_other": "Other"
       }
     }

--- a/custom_components/foxess_modbus/translations/en.json
+++ b/custom_components/foxess_modbus/translations/en.json
@@ -197,6 +197,7 @@
         "usr_tcp232_410s": "USR-TCP232-410s",
         "usr_w610": "USR-W610",
         "waveshare_rs485_to_eth_b": "Waveshare Modbus RTU Relay",
+        "ebyte_na111_e": "Ebyte NA111-E",
         "network_other": "Other"
       }
     }


### PR DESCRIPTION
Adds the Ebyte NA111 family of RS485-to-Ethernet serial servers to the
network adapter dropdown in the config flow.

The NA111, NA111-A, NA111-E and NA111-M share the same firmware and
protocol stack — they differ only in power input (DC 8–28 V, AC 85–265 V,
or PoE) and mounting form factor. All four support Modbus TCP and UDP
out of the box, so a single entry covers the whole series.

Configured with `max_read=100`, matching other capable RS485-to-Ethernet
adapters (Elfin EW11, Waveshare RS485-to-ETH, USR-TCP232-410s).

Tested on a FoxESS KH10 with the NA111-E over Modbus TCP.
Pre-commit hooks (ruff, ruff-format, prettier) pass locally.

Product page: https://www.cdebyte.com/products/NA111-E