### PR TITLE
Update entity_descriptions.py _total_yield_today

### DIFF
--- a/custom_components/foxess_modbus/entities/entity_descriptions.py
+++ b/custom_components/foxess_modbus/entities/entity_descriptions.py
@@ -2143,7 +2143,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
             icon="mdi:export",
             scale=scale,
             # unsure if this actually goes negative
-            validate=[Range(-100, 100)],
+            validate=[Range(-200, 200)],
         )
 
     yield _total_yield_today(


### PR DESCRIPTION
_total_yield_today may exceed 100 kWh.
The value is capped when "validate=[Range(-100, 100)]," is set