### PR TITLE
Add P3-Pro inverter support (OEM variant of H3-Pro)

### DIFF
--- a/custom_components/foxess_modbus/inverter_profiles.py
+++ b/custom_components/foxess_modbus/inverter_profiles.py
@@ -431,8 +431,10 @@ _INVERTER_PROFILES_LIST = [
         versions={None: Inv.H3_PRE180},
         special_registers=H3_REGISTERS,
     ),
-    # E.g. H3-Pro-20.0
-    InverterModelProfile(InverterModel.H3_PRO, r"^H3-Pro-([\d\.]+)").add_connection_type(
+    # E.g. H3-Pro-20.0, P3-Pro-15.0
+    # P3-Pro is an OEM/installer-channel variant of the H3-Pro (H = Home, P = Pro/installer channel);
+    # hardware and Modbus registers are identical.
+    InverterModelProfile(InverterModel.H3_PRO, r"^[HP]3-Pro-([\d\.]+)").add_connection_type(
         ConnectionType.AUX,
         RegisterType.HOLDING,
         versions={Version(1, 22): Inv.H3_PRO_PRE122, None: Inv.H3_PRO_122},


### PR DESCRIPTION
## Summary

The FoxESS **P3-Pro** is an OEM/installer-channel variant of the H3-Pro. The naming reflects the sales channel only (H = Home, P = Pro/installer) — hardware, Modbus registers, firmware versions, and connection type are identical.

This change broadens the `H3_PRO` regex from `^H3-Pro-` to `^[HP]3-Pro-` so both `H3-Pro-*` and `P3-Pro-*` model strings are matched by a single profile entry. This keeps the `INVERTER_PROFILES` dict length assertion intact (no duplicate model keys).

## Changes

- `inverter_profiles.py`: regex `^H3-Pro-([\d\.]+)` → `^[HP]3-Pro-([\d\.]+)`

## Test

Tested on a **P3-Pro-15.0** running the H3_PRO register set with no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)