### PR TITLE
feat: add P3-Smart inverter support

### DIFF
--- a/custom_components/foxess_modbus/common/types.py
+++ b/custom_components/foxess_modbus/common/types.py
@@ -60,6 +60,7 @@ class InverterModel(StrEnum):
     H3_PRO = "H3_PRO"
     H3_SMART = "H3_SMART"
 
+    P3_SMART = "P3_SMART"
     EVO = "EVO"
 
 

--- a/custom_components/foxess_modbus/inverter_profiles.py
+++ b/custom_components/foxess_modbus/inverter_profiles.py
@@ -345,8 +345,15 @@ _INVERTER_PROFILES_LIST = [
         versions={None: Inv.H3_SMART},
         special_registers=H3_SMART_REGISTERS,
     ),
+    # P3-Smart series (e.g. P3-8.0-SH)
+    InverterModelProfile(InverterModel.P3_SMART, r"^P3-([\d\.]+)-SH\d*$").add_connection_type(
+        ConnectionType.AUX,
+        RegisterType.HOLDING,
+        versions={None: Inv.H3_SMART},
+        special_registers=H3_SMART_REGISTERS,
+    ),
     # The H3 seems to use holding registers for everything
-    InverterModelProfile(InverterModel.H3, r"^H3-([\d\.]+)(?:-E)?").add_connection_type(
+    InverterModelProfile(InverterModel.H3, r"^H3-([\d\.]+)").add_connection_type(
         ConnectionType.AUX,
         RegisterType.HOLDING,
         versions={Version(1, 80): Inv.H3_PRE180, None: Inv.H3_180},

--- a/tests/__snapshots__/test_entity_descriptions/test_entities[P3_SMART-AUX-latest].json
+++ b/tests/__snapshots__/test_entity_descriptions/test_entities[P3_SMART-AUX-latest].json
@@ -1,0 +1,1407 @@
+[
+  {
+    "addresses": [
+      37610
+    ],
+    "key": "bat_current_1",
+    "name": "Battery 1 Current",
+    "scale": 0.1,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      38308
+    ],
+    "key": "bat_current_2",
+    "name": "Battery 2 Current",
+    "scale": 0.1,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39238,
+      39237
+    ],
+    "key": "battery_charge",
+    "name": "Battery Charge",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39231,
+      39230
+    ],
+    "key": "battery_charge_1",
+    "name": "Battery 1 Charge",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39236,
+      39235
+    ],
+    "key": "battery_charge_2",
+    "name": "Battery 2 Charge",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39608,
+      39607
+    ],
+    "key": "battery_charge_today",
+    "name": "Battery Charge Today",
+    "scale": 0.01,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39606,
+      39605
+    ],
+    "key": "battery_charge_total",
+    "name": "Battery Charge Total",
+    "scale": 0.01,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39238,
+      39237
+    ],
+    "key": "battery_discharge",
+    "name": "Battery Discharge",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39231,
+      39230
+    ],
+    "key": "battery_discharge_1",
+    "name": "Battery 1 Discharge",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39236,
+      39235
+    ],
+    "key": "battery_discharge_2",
+    "name": "Battery 2 Discharge",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39612,
+      39611
+    ],
+    "key": "battery_discharge_today",
+    "name": "Battery Discharge Today",
+    "scale": 0.01,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39610,
+      39609
+    ],
+    "key": "battery_discharge_total",
+    "name": "Battery Discharge Total",
+    "scale": 0.01,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      37612
+    ],
+    "key": "battery_soc_1",
+    "name": "Battery 1 SoC",
+    "scale": null,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      38310
+    ],
+    "key": "battery_soc_2",
+    "name": "Battery 2 SoC",
+    "scale": null,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      37624
+    ],
+    "key": "battery_soh_1",
+    "name": "Battery 1 SoH",
+    "scale": null,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      38322
+    ],
+    "key": "battery_soh_2",
+    "name": "Battery 2 SoH",
+    "scale": null,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      37611
+    ],
+    "key": "battery_temp_1",
+    "name": "Battery 1 Temp",
+    "scale": 0.1,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      38309
+    ],
+    "key": "battery_temp_2",
+    "name": "Battery 2 Temp",
+    "scale": 0.1,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      37609
+    ],
+    "key": "batvolt_1",
+    "name": "Battery 1 Voltage",
+    "scale": 0.1,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      38307
+    ],
+    "key": "batvolt_2",
+    "name": "Battery 2 Voltage",
+    "scale": 0.1,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      37619
+    ],
+    "key": "bms_cell_mv_high_1",
+    "name": "BMS 1 Cell mV High",
+    "scale": null,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      38317
+    ],
+    "key": "bms_cell_mv_high_2",
+    "name": "BMS 2 Cell mV High",
+    "scale": null,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      37620
+    ],
+    "key": "bms_cell_mv_low_1",
+    "name": "BMS 1 Cell mV Low",
+    "scale": null,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      38318
+    ],
+    "key": "bms_cell_mv_low_2",
+    "name": "BMS 2 Cell mV Low",
+    "scale": null,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      37617
+    ],
+    "key": "bms_cell_temp_high_1",
+    "name": "BMS 1 Cell Temp High",
+    "scale": 0.1,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      38315
+    ],
+    "key": "bms_cell_temp_high_2",
+    "name": "BMS 2 Cell Temp High",
+    "scale": 0.1,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      37618
+    ],
+    "key": "bms_cell_temp_low_1",
+    "name": "BMS 1 Cell Temp Low",
+    "scale": 0.1,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      38316
+    ],
+    "key": "bms_cell_temp_low_2",
+    "name": "BMS 2 Cell Temp Low",
+    "scale": 0.1,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      37632
+    ],
+    "key": "bms_kwh_remaining_1",
+    "name": "BMS 1 kWh Remaining",
+    "scale": 0.01,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      38330
+    ],
+    "key": "bms_kwh_remaining_2",
+    "name": "BMS 2 kWh Remaining",
+    "scale": 0.01,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      38915,
+      38914
+    ],
+    "key": "ct2_meter",
+    "name": "CT2 Meter",
+    "scale": 0.0001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      38917,
+      38916
+    ],
+    "key": "ct2_meter_R",
+    "name": "CT2 Meter R",
+    "scale": 0.0001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      38919,
+      38918
+    ],
+    "key": "ct2_meter_S",
+    "name": "CT2 Meter S",
+    "scale": 0.0001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      38921,
+      38920
+    ],
+    "key": "ct2_meter_T",
+    "name": "CT2 Meter T",
+    "scale": 0.0001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39213,
+      39212
+    ],
+    "key": "eps_power_R",
+    "name": "EPS Power R",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39215,
+      39214
+    ],
+    "key": "eps_power_S",
+    "name": "EPS Power S",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39217,
+      39216
+    ],
+    "key": "eps_power_T",
+    "name": "EPS Power T",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39205,
+      39204
+    ],
+    "key": "eps_rcurrent_R",
+    "name": "EPS Current R",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39207,
+      39206
+    ],
+    "key": "eps_rcurrent_S",
+    "name": "EPS Current S",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39209,
+      39208
+    ],
+    "key": "eps_rcurrent_T",
+    "name": "EPS Current T",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39201
+    ],
+    "key": "eps_rvolt_R",
+    "name": "EPS Voltage_R",
+    "scale": 0.1,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39202
+    ],
+    "key": "eps_rvolt_S",
+    "name": "EPS Voltage_S",
+    "scale": 0.1,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39203
+    ],
+    "key": "eps_rvolt_T",
+    "name": "EPS Voltage_T",
+    "scale": 0.1,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      38815,
+      38814
+    ],
+    "key": "feed_in",
+    "name": "Feed-in",
+    "scale": 0.0001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      38817,
+      38816
+    ],
+    "key": "feed_in_R",
+    "name": "Feed-in R",
+    "scale": 0.0001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      38819,
+      38818
+    ],
+    "key": "feed_in_S",
+    "name": "Feed-in S",
+    "scale": 0.0001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      38821,
+      38820
+    ],
+    "key": "feed_in_T",
+    "name": "Feed-in T",
+    "scale": 0.0001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39616,
+      39615
+    ],
+    "key": "feed_in_energy_today",
+    "name": "Feed-in Today",
+    "scale": 0.01,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39614,
+      39613
+    ],
+    "key": "feed_in_energy_total",
+    "name": "Feed-in Total",
+    "scale": 0.01,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      38815,
+      38814
+    ],
+    "key": "grid_consumption",
+    "name": "Grid Consumption",
+    "scale": 0.0001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      38817,
+      38816
+    ],
+    "key": "grid_consumption_R",
+    "name": "Grid Consumption R",
+    "scale": 0.0001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      38819,
+      38818
+    ],
+    "key": "grid_consumption_S",
+    "name": "Grid Consumption S",
+    "scale": 0.0001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      38821,
+      38820
+    ],
+    "key": "grid_consumption_T",
+    "name": "Grid Consumption T",
+    "scale": 0.0001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39620,
+      39619
+    ],
+    "key": "grid_consumption_energy_today",
+    "name": "Grid Consumption Today",
+    "scale": 0.01,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39618,
+      39617
+    ],
+    "key": "grid_consumption_energy_total",
+    "name": "Grid Consumption Total",
+    "scale": 0.01,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      38815,
+      38814
+    ],
+    "key": "grid_ct",
+    "name": "Grid CT",
+    "scale": 0.0001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      38817,
+      38816
+    ],
+    "key": "grid_ct_R",
+    "name": "Grid CT R",
+    "scale": 0.0001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      38819,
+      38818
+    ],
+    "key": "grid_ct_S",
+    "name": "Grid CT S",
+    "scale": 0.0001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      38821,
+      38820
+    ],
+    "key": "grid_ct_T",
+    "name": "Grid CT T",
+    "scale": 0.0001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39123
+    ],
+    "key": "grid_voltage_R",
+    "name": "Grid Voltage R",
+    "scale": 0.1,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39124
+    ],
+    "key": "grid_voltage_S",
+    "name": "Grid Voltage S",
+    "scale": 0.1,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39125
+    ],
+    "key": "grid_voltage_T",
+    "name": "Grid Voltage T",
+    "scale": 0.1,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39628,
+      39627
+    ],
+    "key": "input_energy_today",
+    "name": "Input Energy Today",
+    "scale": 0.01,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39626,
+      39625
+    ],
+    "key": "input_energy_total",
+    "name": "Input Energy Total",
+    "scale": 0.01,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39127,
+      39126
+    ],
+    "key": "inv_current_R",
+    "name": "Inverter Current R",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39129,
+      39128
+    ],
+    "key": "inv_current_S",
+    "name": "Inverter Current S",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39131,
+      39130
+    ],
+    "key": "inv_current_T",
+    "name": "Inverter Current T",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39135,
+      39134
+    ],
+    "key": "inv_power",
+    "name": "Inverter Power",
+    "scale": 1e-06,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39137,
+      39136
+    ],
+    "key": "inv_power_Q",
+    "name": "Inverter Power (Reactive)",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39257,
+      39256
+    ],
+    "key": "inv_power_Q_R",
+    "name": "Inverter Power (Reactive) R",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39259,
+      39258
+    ],
+    "key": "inv_power_Q_S",
+    "name": "Inverter Power (Reactive) S",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39261,
+      39260
+    ],
+    "key": "inv_power_Q_T",
+    "name": "Inverter Power (Reactive) T",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39249,
+      39248
+    ],
+    "key": "inv_power_R",
+    "name": "Inverter Power R",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39251,
+      39250
+    ],
+    "key": "inv_power_S",
+    "name": "Inverter Power S",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39253,
+      39252
+    ],
+    "key": "inv_power_T",
+    "name": "Inverter Power T",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39229,
+      39228
+    ],
+    "key": "invbatcurrent_1",
+    "name": "Inverter Battery 1 Current",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39234,
+      39233
+    ],
+    "key": "invbatcurrent_2",
+    "name": "Inverter Battery 2 Current",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39238,
+      39237
+    ],
+    "key": "invbatpower",
+    "name": "Inverter Battery Power",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39231,
+      39230
+    ],
+    "key": "invbatpower_1",
+    "name": "Inverter Battery 1 Power",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39236,
+      39235
+    ],
+    "key": "invbatpower_2",
+    "name": "Inverter Battery 2 Power",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39227
+    ],
+    "key": "invbatvolt_1",
+    "name": "Inverter Battery 1 Voltage",
+    "scale": 0.1,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39232
+    ],
+    "key": "invbatvolt_2",
+    "name": "Inverter Battery 2 Voltage",
+    "scale": 0.1,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39067,
+      39068,
+      39069
+    ],
+    "faults": [
+      [
+        "PV Over-voltage",
+        "DC arc fault",
+        "String reverse connection",
+        null,
+        null,
+        null,
+        null,
+        "Grid Lost Fault",
+        "Grid Voltage Fault",
+        null,
+        null,
+        "Grid Frequency Fault",
+        null,
+        null,
+        "Output Over-current Fault",
+        "Output DC Over-current Fault"
+      ],
+      [
+        "Residual Current Consistency Fault",
+        "Ground Connection Fault",
+        "Low Insulation Resistante Fault",
+        "Inverter Over-temperature Fault",
+        null,
+        null,
+        null,
+        null,
+        null,
+        "Energy Storage Equipment Abnormal Fault",
+        "Isolated Island Fault",
+        null,
+        null,
+        null,
+        "Off-grid Output Overload Fault",
+        null
+      ],
+      [
+        null,
+        null,
+        null,
+        "External Fan Fault",
+        "Energy Storage Reverse Connection Fault",
+        null,
+        null,
+        null,
+        null,
+        "Meter Lost Fault",
+        "BMS Lost Fault",
+        null,
+        null,
+        null,
+        null,
+        null
+      ]
+    ],
+    "key": "inverter_fault_code",
+    "name": "Inverter Fault Code",
+    "type": "fault-sensor"
+  },
+  {
+    "addresses": [
+      39063,
+      39065
+    ],
+    "key": "inverter_state",
+    "name": "Inverter State",
+    "type": "inverter-state-sensor"
+  },
+  {
+    "addresses": [
+      39141
+    ],
+    "key": "invtemp",
+    "name": "Inverter Temp",
+    "scale": 0.1,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39632,
+      39631
+    ],
+    "key": "load_energy_today",
+    "name": "Load Energy Today",
+    "scale": 0.01,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39226,
+      39225
+    ],
+    "key": "load_power",
+    "name": "Load Power",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39220,
+      39219
+    ],
+    "key": "load_power_R",
+    "name": "Load Power R",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39222,
+      39221
+    ],
+    "key": "load_power_S",
+    "name": "Load Power S",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39224,
+      39223
+    ],
+    "key": "load_power_T",
+    "name": "Load Power T",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39630,
+      39629
+    ],
+    "key": "load_power_total",
+    "name": "Load Energy Total",
+    "scale": 0.01,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      36003
+    ],
+    "is_hex": true,
+    "key": "manager_version",
+    "name": "Version: Manager",
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      36001
+    ],
+    "is_hex": true,
+    "key": "master_version",
+    "name": "Version: Master",
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      46607
+    ],
+    "key": "max_charge_current",
+    "name": "Max Charge Current",
+    "scale": 0.1,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      46607
+    ],
+    "key": "max_charge_current",
+    "name": "Max Charge Current",
+    "scale": 0.1,
+    "type": "number"
+  },
+  {
+    "addresses": [
+      46608
+    ],
+    "key": "max_discharge_current",
+    "name": "Max Discharge Current",
+    "scale": 0.1,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      46608
+    ],
+    "key": "max_discharge_current",
+    "name": "Max Discharge Current",
+    "scale": 0.1,
+    "type": "number"
+  },
+  {
+    "addresses": [
+      46610
+    ],
+    "key": "max_soc",
+    "name": "Max SoC",
+    "scale": null,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      46610
+    ],
+    "key": "max_soc",
+    "name": "Max SoC",
+    "scale": null,
+    "type": "number"
+  },
+  {
+    "addresses": [
+      46609
+    ],
+    "key": "min_soc",
+    "name": "Min SoC",
+    "scale": null,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      46609
+    ],
+    "key": "min_soc",
+    "name": "Min SoC",
+    "scale": null,
+    "type": "number"
+  },
+  {
+    "addresses": [
+      46611
+    ],
+    "key": "min_soc_on_grid",
+    "name": "Min SoC (On Grid)",
+    "scale": null,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      46611
+    ],
+    "key": "min_soc_on_grid",
+    "name": "Min SoC (On Grid)",
+    "scale": null,
+    "type": "number"
+  },
+  {
+    "addresses": [
+      39071
+    ],
+    "key": "pv1_current",
+    "name": "PV1 Current",
+    "scale": 0.01,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "key": "pv1_energy_total",
+    "method": "left",
+    "name": "PV1 Power Total",
+    "source": "pv1_power",
+    "type": "integration-sensor",
+    "unit_time": "h"
+  },
+  {
+    "addresses": [
+      39280,
+      39279
+    ],
+    "key": "pv1_power",
+    "name": "PV1 Power",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39070
+    ],
+    "key": "pv1_voltage",
+    "name": "PV1 Voltage",
+    "scale": 0.1,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39073
+    ],
+    "key": "pv2_current",
+    "name": "PV2 Current",
+    "scale": 0.01,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "key": "pv2_energy_total",
+    "method": "left",
+    "name": "PV2 Power Total",
+    "source": "pv2_power",
+    "type": "integration-sensor",
+    "unit_time": "h"
+  },
+  {
+    "addresses": [
+      39282,
+      39281
+    ],
+    "key": "pv2_power",
+    "name": "PV2 Power",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39072
+    ],
+    "key": "pv2_voltage",
+    "name": "PV2 Voltage",
+    "scale": 0.1,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39075
+    ],
+    "key": "pv3_current",
+    "name": "PV3 Current",
+    "scale": 0.01,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "key": "pv3_energy_total",
+    "method": "left",
+    "name": "PV3 Power Total",
+    "source": "pv3_power",
+    "type": "integration-sensor",
+    "unit_time": "h"
+  },
+  {
+    "addresses": [
+      39284,
+      39283
+    ],
+    "key": "pv3_power",
+    "name": "PV3 Power",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39074
+    ],
+    "key": "pv3_voltage",
+    "name": "PV3 Voltage",
+    "scale": 0.1,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39077
+    ],
+    "key": "pv4_current",
+    "name": "PV4 Current",
+    "scale": 0.01,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "key": "pv4_energy_total",
+    "method": "left",
+    "name": "PV4 Power Total",
+    "source": "pv4_power",
+    "type": "integration-sensor",
+    "unit_time": "h"
+  },
+  {
+    "addresses": [
+      39286,
+      39285
+    ],
+    "key": "pv4_power",
+    "name": "PV4 Power",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39076
+    ],
+    "key": "pv4_voltage",
+    "name": "PV4 Voltage",
+    "scale": 0.1,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "key": "pv_power_now",
+    "name": "PV Power",
+    "sources": [
+      "pv1_power",
+      "pv2_power",
+      "pv3_power",
+      "pv4_power"
+    ],
+    "type": "lambda"
+  },
+  {
+    "addresses": [
+      39265,
+      39264
+    ],
+    "key": "rpower_S_R",
+    "name": "Inverter Power (Apparent) R",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39267,
+      39266
+    ],
+    "key": "rpower_S_S",
+    "name": "Inverter Power (Apparent) S",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39269,
+      39268
+    ],
+    "key": "rpower_S_T",
+    "name": "Inverter Power (Apparent) T",
+    "scale": 0.001,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      36002
+    ],
+    "is_hex": true,
+    "key": "slave_version",
+    "name": "Version: Slave",
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39604,
+      39603
+    ],
+    "key": "solar_energy_today",
+    "name": "Solar Generation Today",
+    "scale": 0.01,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39602,
+      39601
+    ],
+    "key": "solar_energy_total",
+    "name": "Solar Generation Total",
+    "scale": 0.01,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39624,
+      39623
+    ],
+    "key": "total_yield_today",
+    "name": "Yield Today",
+    "scale": 0.01,
+    "signed": true,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      39622,
+      39621
+    ],
+    "key": "total_yield_total",
+    "name": "Yield Total",
+    "scale": 0.01,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
+      49203
+    ],
+    "key": "work_mode",
+    "name": "Work Mode",
+    "type": "select",
+    "values": {
+      "1": "Self Use",
+      "2": "Feed-in First",
+      "3": "Back-up",
+      "4": "Peak Shaving"
+    }
+  }
+]


### PR DESCRIPTION
P3-Smart is an OEM rebadge of H3-Smart. Uses the same Inv.H3_SMART flag and H3_SMART_REGISTERS.

**Changes from #954:**
- Fixed regex to handle trailing revision digits: `^P3-([\d\.]+)-SH\d*$`
  (P3 models report as `P3-10.0-SH1`, not `P3-10.0-SH`)
- Includes test snapshot

Closes #930. Supersedes #954.

Co-authored-by: koushyk
Reviewed-by: scruysberghs (tested on live P3-10.0-SH1)