### PR TITLE
feat: add P3-Pro inverter support (OEM variant of H3-Pro)

### DIFF
--- a/custom_components/foxess_modbus/inverter_profiles.py
+++ b/custom_components/foxess_modbus/inverter_profiles.py
@@ -438,8 +438,10 @@ _INVERTER_PROFILES_LIST = [
         versions={None: Inv.H3_PRE180},
         special_registers=H3_REGISTERS,
     ),
-    # E.g. H3-Pro-20.0
-    InverterModelProfile(InverterModel.H3_PRO, r"^H3-Pro-([\d\.]+)").add_connection_type(
+    # E.g. H3-Pro-20.0, P3-Pro-15.0
+    # P3-Pro is an OEM/installer-channel variant of the H3-Pro (H = Home, P = Pro/installer channel);
+    # hardware and Modbus registers are identical.
+    InverterModelProfile(InverterModel.H3_PRO, r"^[HP]3-Pro-([\d\.]+)").add_connection_type(
         ConnectionType.AUX,
         RegisterType.HOLDING,
         versions={Version(1, 22): Inv.H3_PRO_PRE122, None: Inv.H3_PRO_122},


### PR DESCRIPTION
P3-Pro is an OEM/installer-channel variant of H3-Pro. Broadens the H3_PRO regex
from `^H3-Pro-` to `^[HP]3-Pro-` — no new enum or Inv flag needed.

Tested on P3-Pro-15.0.

Supersedes #1160.

Co-authored-by: ropheb