### PR TITLE
fix: allow negative temperature readings

### DIFF
--- a/custom_components/foxess_modbus/entities/entity_descriptions.py
+++ b/custom_components/foxess_modbus/entities/entity_descriptions.py
@@ -1546,7 +1546,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         native_unit_of_measurement="°C",
         scale=0.1,
         round_to=0.5,
-        validate=[Range(0, 100)],
+        validate=[Range(-50, 100)],
     )
     yield ModbusSensorDescription(
         key="ambtemp",
@@ -1564,7 +1564,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
         native_unit_of_measurement="°C",
         scale=0.1,
         round_to=0.5,
-        validate=[Range(0, 100)],
+        validate=[Range(-50, 100)],
     )
     yield ModbusBatterySensorDescription(
         key="bms_charge_rate",
@@ -2393,7 +2393,7 @@ def _bms_entities() -> Iterable[EntityFactory]:
             state_class=SensorStateClass.MEASUREMENT,
             native_unit_of_measurement="°C",
             scale=0.1,
-            validate=[Range(0, 100)],
+            validate=[Range(-50, 100)],
         )
         yield ModbusBatterySensorDescription(
             key=f"bms_cell_temp_high{key_suffix}",
@@ -2404,7 +2404,7 @@ def _bms_entities() -> Iterable[EntityFactory]:
             state_class=SensorStateClass.MEASUREMENT,
             native_unit_of_measurement="°C",
             scale=0.1,
-            validate=[Range(0, 100)],
+            validate=[Range(-50, 100)],
         )
         yield ModbusBatterySensorDescription(
             key=f"bms_cell_temp_low{key_suffix}",
@@ -2415,7 +2415,7 @@ def _bms_entities() -> Iterable[EntityFactory]:
             state_class=SensorStateClass.MEASUREMENT,
             native_unit_of_measurement="°C",
             scale=0.1,
-            validate=[Range(0, 100)],
+            validate=[Range(-50, 100)],
         )
         yield ModbusBatterySensorDescription(
             key=f"bms_cell_mv_high{key_suffix}",


### PR DESCRIPTION
Temperature sensors (inverter, ambient, battery, BMS cell high/low) used `validate=[Range(0, 100)]`, so any sub-zero reading was rejected and the sensor went unavailable in cold climates. This lowers the bound to `Range(-50, 100)`.

Validators aren't serialised into the entity snapshots, so no snapshot changes are required.

Fixes #1000
