### PR TITLE
fix: start even when the recorder is unavailable

### DIFF
--- a/custom_components/foxess_modbus/manifest.json
+++ b/custom_components/foxess_modbus/manifest.json
@@ -1,9 +1,9 @@
 {
   "domain": "foxess_modbus",
   "name": "FoxESS - Modbus",
+  "after_dependencies": ["energy", "integration", "logbook"],
   "codeowners": ["@nathanmarlor"],
   "config_flow": true,
-  "dependencies": ["energy", "integration", "logbook"],
   "documentation": "https://github.com/nathanmarlor/foxess_modbus",
   "integration_type": "service",
   "iot_class": "local_push",


### PR DESCRIPTION
`energy` and `logbook` are listed as hard `dependencies`, and both require the `recorder`. If the recorder/database fails to start (corrupt DB, slow disk, etc.), those dependencies fail and Home Assistant refuses to set up foxess_modbus at all — so a database problem takes the whole inverter integration offline.

None of these domains are needed during our import or setup, so this moves them to `after_dependencies`. Home Assistant will still set us up *after* them when they're present (preserving energy-dashboard ordering), but a recorder failure no longer blocks the integration.

Fixes #1120
Fixes #955
