### PR TITLE
fix: detect H3-x.x-M as H3-Smart

### DIFF
--- a/custom_components/foxess_modbus/inverter_profiles.py
+++ b/custom_components/foxess_modbus/inverter_profiles.py
@@ -338,8 +338,11 @@ _INVERTER_PROFILES_LIST = [
         versions={Version(1, 33): Inv.KH_PRE133, None: Inv.KH_133},
         special_registers=KH_REGISTERS,
     ),
-    # H3-Smart has to appear before H3
-    InverterModelProfile(InverterModel.H3_SMART, r"^H3-([\d\.]+)-Smart").add_connection_type(
+    # H3-Smart has to appear before H3.
+    # The "-M" suffix (e.g. H3-10.0-M) is an OEM/installer variant of the H3-Smart (Gen2), confirmed
+    # by FoxESS - see https://github.com/nathanmarlor/foxess_modbus/issues/1023. Without this it falls
+    # through to the plain H3 profile and reads the wrong (legacy) register map.
+    InverterModelProfile(InverterModel.H3_SMART, r"^H3-([\d\.]+)-(?:Smart|M)").add_connection_type(
         ConnectionType.AUX,
         RegisterType.HOLDING,
         versions={None: Inv.H3_SMART},


### PR DESCRIPTION
The `-M` suffix (e.g. `H3-10.0-M`, `H3-5.0-M`) is an OEM/installer-channel variant of the H3-Smart (Gen2), confirmed by FoxESS in the issue threads. The H3-Smart matcher only matched the literal `-Smart`, so `-M` units fell through to the plain H3 profile and were read with the legacy H3 register map (31000/32000/41000) — producing "invalid registers detected" and garbage values.

This extends the matcher to `^H3-([\d\.]+)-(?:Smart|M)` (non-capturing group, so the capacity group is unchanged). No new model profile is added, so no snapshot changes are needed.

Fixes #1023
Fixes #1140
Refs #1080, #1158
