### PR TITLE
fix: add Grid Frequency sensor for H3-Smart

### DIFF
--- a/custom_components/foxess_modbus/entities/entity_descriptions.py
+++ b/custom_components/foxess_modbus/entities/entity_descriptions.py
@@ -1498,7 +1498,7 @@ def _inverter_entities() -> Iterable[EntityFactory]:
             ),
             ModbusAddressesSpec(holding=[31015], models=Inv.H3_SET),
             ModbusAddressesSpec(holding=[38847, 38846], models=Inv.H3_PRO_PRE122),
-            ModbusAddressesSpec(holding=[39139], models=Inv.H3_PRO_122 | Inv.EVO),
+            ModbusAddressesSpec(holding=[39139], models=Inv.H3_PRO_122 | Inv.H3_SMART | Inv.EVO),
         ],
         entity_registry_enabled_default=False,
         name="Grid Frequency",

--- a/tests/__snapshots__/test_entity_descriptions/test_entities[1KOMMA5-AUX-latest].json
+++ b/tests/__snapshots__/test_entity_descriptions/test_entities[1KOMMA5-AUX-latest].json
@@ -1306,6 +1306,16 @@
   },
   {
     "addresses": [
+      39139
+    ],
+    "key": "rfreq",
+    "name": "Grid Frequency",
+    "scale": 0.01,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
       39265,
       39264
     ],

--- a/tests/__snapshots__/test_entity_descriptions/test_entities[ENPAL_IX-AUX-latest].json
+++ b/tests/__snapshots__/test_entity_descriptions/test_entities[ENPAL_IX-AUX-latest].json
@@ -1306,6 +1306,16 @@
   },
   {
     "addresses": [
+      39139
+    ],
+    "key": "rfreq",
+    "name": "Grid Frequency",
+    "scale": 0.01,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
       39265,
       39264
     ],

--- a/tests/__snapshots__/test_entity_descriptions/test_entities[H3_SMART-AUX-latest].json
+++ b/tests/__snapshots__/test_entity_descriptions/test_entities[H3_SMART-AUX-latest].json
@@ -1306,6 +1306,16 @@
   },
   {
     "addresses": [
+      39139
+    ],
+    "key": "rfreq",
+    "name": "Grid Frequency",
+    "scale": 0.01,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
       39265,
       39264
     ],

--- a/tests/__snapshots__/test_entity_descriptions/test_entities[P3_SMART-AUX-latest].json
+++ b/tests/__snapshots__/test_entity_descriptions/test_entities[P3_SMART-AUX-latest].json
@@ -1306,6 +1306,16 @@
   },
   {
     "addresses": [
+      39139
+    ],
+    "key": "rfreq",
+    "name": "Grid Frequency",
+    "scale": 0.01,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
       39265,
       39264
     ],

--- a/tests/__snapshots__/test_entity_descriptions/test_entities[SK-HWR-SMART-AUX-latest].json
+++ b/tests/__snapshots__/test_entity_descriptions/test_entities[SK-HWR-SMART-AUX-latest].json
@@ -1306,6 +1306,16 @@
   },
   {
     "addresses": [
+      39139
+    ],
+    "key": "rfreq",
+    "name": "Grid Frequency",
+    "scale": 0.01,
+    "signed": false,
+    "type": "sensor"
+  },
+  {
+    "addresses": [
       39265,
       39264
     ],


### PR DESCRIPTION
The `rfreq` (Grid Frequency) sensor had address specs for H1/KH/H3/H3-Pro/EVO but **no `Inv.H3_SMART`**, so the entity could never populate on H3-Smart inverters.

H3-Smart shares the H3-Pro 39xxx register block (it already shares 39141 inverter temp, 39134/39135, 39136/39137, etc.), so register **39139** applies for grid frequency too. This adds `Inv.H3_SMART` to the 39139 spec and regenerates the 5 affected H3-Smart-family snapshots (H3_SMART, P3_SMART, ENPAL_IX, 1KOMMA5, SK-HWR-SMART) — each gains only the Grid Frequency entity.

Fixes #1131
