### PR TITLE
Add Solarwatt Vision (rebadged FoxESS H3 Smart) support

### DIFF
--- a/custom_components/foxess_modbus/common/types.py
+++ b/custom_components/foxess_modbus/common/types.py
@@ -57,6 +57,7 @@ class InverterModel(StrEnum):
     SOLAVITA_SP = "SOLAVITA-SP"
     ATRONIX_AX = "ATRONIX_AX"
     ENPAL_IX = "ENPAL_IX"
+    SOLARWATT_VISION = "VSN"
     ONE_KOMMA_FIVE = "1KOMMA5"
 
     H3_PRO = "H3_PRO"

--- a/custom_components/foxess_modbus/inverter_profiles.py
+++ b/custom_components/foxess_modbus/inverter_profiles.py
@@ -482,6 +482,14 @@ _INVERTER_PROFILES_LIST = [
         RegisterType.HOLDING,
         versions={None: Inv.EVO},
     ),
+    # Solarwatt Vision (rebadged FoxESS H3 Smart)
+    # E.g. VSN THREE 12KW
+    InverterModelProfile(InverterModel.SOLARWATT_VISION, r"^VSN THREE ([\d\.]+)KW$").add_connection_type(
+        ConnectionType.AUX,
+        RegisterType.HOLDING,
+        versions={None: Inv.H3_SMART},
+        special_registers=H3_SMART_REGISTERS,
+    ),
 ]
 
 INVERTER_PROFILES = {x.model: x for x in _INVERTER_PROFILES_LIST}


### PR DESCRIPTION
## What this adds

Native support for the **Solarwatt Vision** inverter, which is electrically identical to the **FoxESS H3 Smart**. Until now it had to be added by hand-editing the integration files (see discussion #956), which gets overwritten on every HACS update.

## Details

The Solarwatt Vision reports a model string of `VSN THREE <kW>KW` (e.g. `VSN THREE 12KW`). This PR:

- adds `SOLARWATT_VISION = "VSN"` to the `InverterModel` enum, and
- adds an `InverterModelProfile` that maps `^VSN THREE ([\d\.]+)KW$` to the existing **H3 Smart** register set via AUX / holding registers (mirroring the built-in H3 Smart profile). The regex captures the kW rating, so it covers the different capacities.

## Testing

Tested on **v1.15.0** with a real **Solarwatt Vision THREE 12 kW**:

- inverter is detected automatically (device shows `VSN THREE 12KW`),
- battery SoC / power, voltages, temperatures and lifetime energy totals all read correctly,
- no errors in the log.

Happy to also add a line to the supported-hardware list in the README or add a test if that's preferred. Thanks for this great integration! 🙏