### PR TITLE
feat: added support for a-Tronix AX Plus models

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Supported models:
 - STAR
 - Solavita SP
 - a-TroniX AX
+- a-Tronix AX Plus
 - Enpal
 - 1KOMMA5°
 

--- a/custom_components/foxess_modbus/common/types.py
+++ b/custom_components/foxess_modbus/common/types.py
@@ -56,6 +56,7 @@ class InverterModel(StrEnum):
     STAR_H3 = "STAR-H3"
     SOLAVITA_SP = "SOLAVITA-SP"
     ATRONIX_AX = "ATRONIX_AX"
+    ATRONIX_AX_PLUS = "ATRONIX_AX_PLUS"
     ENPAL_IX = "ENPAL_IX"
     ONE_KOMMA_FIVE = "1KOMMA5"
 

--- a/custom_components/foxess_modbus/inverter_profiles.py
+++ b/custom_components/foxess_modbus/inverter_profiles.py
@@ -448,6 +448,14 @@ _INVERTER_PROFILES_LIST = [
         versions={None: Inv.H3_PRE180},
         special_registers=H3_REGISTERS,
     ),
+    # a-TroniX AX Plus 
+    # These have the form 'AX Plus 10kW-3ph'' (the 3ph standing for '3 phase'). There are other powers, too 
+    InverterModelProfile(InverterModel.ATRONIX_AX_PLUS, r"^AX Plus ([\d\.]+)kW-3ph").add_connection_type(
+        ConnectionType.AUX,
+        RegisterType.HOLDING,
+        versions={None: Inv.H3_SMART},
+        special_registers=H3_SMART_REGISTERS,
+    ),
     # E.g. H3-Pro-20.0, P3-Pro-15.0
     # P3-Pro is an OEM/installer-channel variant of the H3-Pro (H = Home, P = Pro/installer channel);
     # hardware and Modbus registers are identical.


### PR DESCRIPTION
Besides the AX models from a-Tronix there are the AX Plus models which are H3 Smart rebrands. I added the support for my AX Plus locally, but I think it is a good idea to integrate it in every version. 

**What this adds**
Native support for the a-Tronix AX Plus hybridinverter, which is identical to the FoxESS H3 Smart. Until now it had to be added by hand-editing the integration files, which gets overwritten on every HACS update.

**Details**
a-tronix reports a model string of AX Plus <XX>kW-3ph (e.g. AX Plus 10kW-3ph) This PR:

- adds ATRONIX_AX_PLUS = "ATRONIX_AX_PLUS" to the InverterModel enum, and
- adds an InverterModelProfile that maps ^AX Plus ([\d\.]+)kW-3ph to the existing H3 Smart register set via AUX / holding registers (mirroring the built-in H3 Smart profile). 
- adds a line to the supported-hardware list in the README 


**Testing**
Tested on v. 1.13 and v1.15.0 with a AX Plus 10kW-3ph

inverter is detected automatically (device shows AX Plus 10kW-3ph)

all registers are read correctly,
no errors in the log.

