### PR TITLE
Add charge period support for H3 Smart / H3 Pro (time-group system)

### DIFF
--- a/custom_components/foxess_modbus/entities/charge_period_descriptions.py
+++ b/custom_components/foxess_modbus/entities/charge_period_descriptions.py
@@ -9,6 +9,63 @@ from .modbus_charge_period_config import ModbusChargePeriodFactory
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
+
+# The H3 Smart defines its charge periods via the time-group system (Table 3-11).
+# Each group is a contiguous block of 10 registers, starting at 48010 + 10*(N-1).
+# We use groups 1 and 2, which are the same groups the FoxESS app uses for its charge periods, so that
+# the card and the app stay in sync. Unlike the H1, force charge is controlled by a dedicated enable
+# register (the group's enable), rather than being inferred from the start/end times, so these factories
+# use enable_force_charge_from_enable_address=True.
+def _h3_group_base(group: int) -> int:
+    """Returns the base address of the given time group (1-based)."""
+    return 48010 + 10 * (group - 1)
+
+
+def _h3_charge_period_factory(
+    group: int,
+    period_start_key: str,
+    period_start_name: str,
+    period_end_key: str,
+    period_end_name: str,
+    enable_force_charge_key: str,
+    enable_force_charge_name: str,
+    enable_charge_from_grid_key: str,
+    enable_charge_from_grid_name: str,
+) -> ModbusChargePeriodFactory:
+    base = _h3_group_base(group)
+    return ModbusChargePeriodFactory(
+        addresses=[
+            ChargePeriodAddressSpec(
+                holding=ModbusChargePeriodAddressConfig(
+                    period_start_address=base + 1,
+                    period_end_address=base + 2,
+                    # 'Enable charge from grid' is determined by whether the force-charge power (FDPWR,
+                    # offset +6) is non-zero. We point this at the FDPWR register so that the resulting
+                    # binary sensor (device class power) also serves as the marker entity that the
+                    # charge-period card uses to discover supported inverters.
+                    enable_charge_from_grid_address=base + 6,
+                    enable_address=base,
+                    work_mode_address=base + 3,
+                    soc_address=base + 4,
+                    fdsoc_address=base + 5,
+                    fdpwr_address=base + 6,
+                    enable_flag_address=base + 9,
+                ),
+                models=Inv.H3_SMART,
+            ),
+        ],
+        period_start_key=period_start_key,
+        period_start_name=period_start_name,
+        period_end_key=period_end_key,
+        period_end_name=period_end_name,
+        enable_force_charge_key=enable_force_charge_key,
+        enable_force_charge_name=enable_force_charge_name,
+        enable_charge_from_grid_key=enable_charge_from_grid_key,
+        enable_charge_from_grid_name=enable_charge_from_grid_name,
+        enable_force_charge_from_enable_address=True,
+    )
+
+
 CHARGE_PERIODS = [
     ModbusChargePeriodFactory(
         addresses=[
@@ -65,5 +122,27 @@ CHARGE_PERIODS = [
         enable_force_charge_name="Period 2 - Enable Force Charge",
         enable_charge_from_grid_key="time_period_2_enable_charge_from_grid",
         enable_charge_from_grid_name="Period 2 - Enable Charge from Grid",
+    ),
+    _h3_charge_period_factory(
+        1,
+        "time_period_1_start",
+        "Period 1 - Start",
+        "time_period_1_end",
+        "Period 1 - End",
+        "time_period_1_enable_force_charge",
+        "Period 1 - Enable Force Charge",
+        "time_period_1_enable_charge_from_grid",
+        "Period 1 - Enable Charge from Grid",
+    ),
+    _h3_charge_period_factory(
+        2,
+        "time_period_2_start",
+        "Period 2 - Start",
+        "time_period_2_end",
+        "Period 2 - End",
+        "time_period_2_enable_force_charge",
+        "Period 2 - Enable Force Charge",
+        "time_period_2_enable_charge_from_grid",
+        "Period 2 - Enable Charge from Grid",
     ),
 ]

--- a/custom_components/foxess_modbus/entities/charge_period_descriptions.py
+++ b/custom_components/foxess_modbus/entities/charge_period_descriptions.py
@@ -50,6 +50,10 @@ def _h3_charge_period_factory(
                     fdsoc_address=base + 5,
                     fdpwr_address=base + 6,
                     enable_flag_address=base + 9,
+                    # The global Max SoC / Min SoC OnGrid registers are mirrored into the group's SoC
+                    # bounds (offset +4), matching how the FoxESS app configures a charge period.
+                    max_soc_global_address=46610,
+                    min_soc_global_address=46611,
                 ),
                 models=Inv.H3_PRO_SET | Inv.H3_SMART,
             ),

--- a/custom_components/foxess_modbus/entities/charge_period_descriptions.py
+++ b/custom_components/foxess_modbus/entities/charge_period_descriptions.py
@@ -10,12 +10,12 @@ from .modbus_charge_period_config import ModbusChargePeriodFactory
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 
-# The H3 Smart defines its charge periods via the time-group system (Table 3-11).
-# Each group is a contiguous block of 10 registers, starting at 48010 + 10*(N-1).
-# We use groups 1 and 2, which are the same groups the FoxESS app uses for its charge periods, so that
-# the card and the app stay in sync. Unlike the H1, force charge is controlled by a dedicated enable
-# register (the group's enable), rather than being inferred from the start/end times, so these factories
-# use enable_force_charge_from_enable_address=True.
+# The H3 Smart (and H3 Pro, which shares the same register map) defines its charge periods via the
+# time-group system (Table 3-11). Each group is a contiguous block of 10 registers, starting at
+# 48010 + 10*(N-1). We use groups 1 and 2, which are the same groups the FoxESS app uses for its charge
+# periods, so that the card and the app stay in sync. Unlike the H1, force charge is controlled by a
+# dedicated enable register (the group's enable), rather than being inferred from the start/end times, so
+# these factories use enable_force_charge_from_enable_address=True.
 def _h3_group_base(group: int) -> int:
     """Returns the base address of the given time group (1-based)."""
     return 48010 + 10 * (group - 1)
@@ -51,7 +51,7 @@ def _h3_charge_period_factory(
                     fdpwr_address=base + 6,
                     enable_flag_address=base + 9,
                 ),
-                models=Inv.H3_SMART,
+                models=Inv.H3_PRO_SET | Inv.H3_SMART,
             ),
         ],
         period_start_key=period_start_key,

--- a/custom_components/foxess_modbus/entities/modbus_charge_period_config.py
+++ b/custom_components/foxess_modbus/entities/modbus_charge_period_config.py
@@ -42,6 +42,10 @@ class ModbusChargePeriodAddressConfig:
     fdsoc_address: int | None = None
     fdpwr_address: int | None = None
     enable_flag_address: int | None = None
+    # The global Max SoC / Min SoC OnGrid registers which the time-period system mirrors into the group's
+    # SoC bounds (offset +4). These are the GUI-editable values (e.g. 46610 / 46611 on the H3 Smart/H3 Pro).
+    max_soc_global_address: int | None = None
+    min_soc_global_address: int | None = None
 
 
 @dataclass(frozen=True)
@@ -121,6 +125,16 @@ class ChargePeriodAddressSpec:
         """Gets a InverterModelSpec instance to describe the time-group enable flag address"""
 
         return self._get_address(lambda x: x.enable_flag_address)
+
+    def get_max_soc_global_address(self) -> InverterModelSpec:
+        """Gets a InverterModelSpec instance to describe the global Max SoC address"""
+
+        return self._get_address(lambda x: x.max_soc_global_address)
+
+    def get_min_soc_global_address(self) -> InverterModelSpec:
+        """Gets a InverterModelSpec instance to describe the global Min SoC OnGrid address"""
+
+        return self._get_address(lambda x: x.min_soc_global_address)
 
     def _get_address(self, accessor: Callable[[ModbusChargePeriodAddressConfig], int | None]) -> InverterModelSpec:
         addresses: dict[RegisterType, list[int] | None] = {}

--- a/custom_components/foxess_modbus/entities/modbus_charge_period_config.py
+++ b/custom_components/foxess_modbus/entities/modbus_charge_period_config.py
@@ -31,6 +31,16 @@ class ModbusChargePeriodAddressConfig:
     period_start_address: int
     period_end_address: int
     enable_charge_from_grid_address: int
+    # The following are used by inverters which define a charge period via the time-period/group system
+    # (e.g. the H3 Smart). On such inverters the charge period is a contiguous block of registers, rather
+    # than the 3 independent registers used by the H1. The enable_address doubles as the base address of
+    # the block.
+    enable_address: int | None = None
+    work_mode_address: int | None = None
+    soc_address: int | None = None
+    fdsoc_address: int | None = None
+    fdpwr_address: int | None = None
+    enable_flag_address: int | None = None
 
 
 @dataclass(frozen=True)
@@ -81,10 +91,41 @@ class ChargePeriodAddressSpec:
 
         return self._get_address(lambda x: x.enable_charge_from_grid_address)
 
-    def _get_address(self, accessor: Callable[[ModbusChargePeriodAddressConfig], int]) -> InverterModelSpec:
+    def get_enable_address(self) -> InverterModelSpec:
+        """Gets a InverterModelSpec instance to describe the time-group enable address"""
+
+        return self._get_address(lambda x: x.enable_address)
+
+    def get_work_mode_address(self) -> InverterModelSpec:
+        """Gets a InverterModelSpec instance to describe the time-group work mode address"""
+
+        return self._get_address(lambda x: x.work_mode_address)
+
+    def get_soc_address(self) -> InverterModelSpec:
+        """Gets a InverterModelSpec instance to describe the time-group SoC address"""
+
+        return self._get_address(lambda x: x.soc_address)
+
+    def get_fdsoc_address(self) -> InverterModelSpec:
+        """Gets a InverterModelSpec instance to describe the time-group FDSOC address"""
+
+        return self._get_address(lambda x: x.fdsoc_address)
+
+    def get_fdpwr_address(self) -> InverterModelSpec:
+        """Gets a InverterModelSpec instance to describe the time-group force-charge power address"""
+
+        return self._get_address(lambda x: x.fdpwr_address)
+
+    def get_enable_flag_address(self) -> InverterModelSpec:
+        """Gets a InverterModelSpec instance to describe the time-group enable flag address"""
+
+        return self._get_address(lambda x: x.enable_flag_address)
+
+    def _get_address(self, accessor: Callable[[ModbusChargePeriodAddressConfig], int | None]) -> InverterModelSpec:
         addresses: dict[RegisterType, list[int] | None] = {}
         for register_type, address_config in self.register_types.items():
-            addresses[register_type] = [accessor(address_config)]
+            address = accessor(address_config)
+            addresses[register_type] = [address] if address is not None else None
         return ModbusAddressSpecBase(addresses, self.models)
 
 
@@ -109,6 +150,7 @@ class ModbusChargePeriodFactory:
         enable_force_charge_name: str,
         enable_charge_from_grid_key: str,
         enable_charge_from_grid_name: str,
+        enable_force_charge_from_enable_address: bool = False,
     ) -> None:
         self.address_specs = addresses
 
@@ -120,6 +162,7 @@ class ModbusChargePeriodFactory:
         period_start_address = [x.get_start_address() for x in addresses]
         period_end_address = [x.get_end_address() for x in addresses]
         enable_charge_from_grid_address = [x.get_enable_charge_from_grid_address() for x in addresses]
+        enable_address = [x.get_enable_address() for x in addresses]
 
         self.period_start = ModbusChargePeriodStartEndSensorDescription(
             key=period_start_key,
@@ -137,13 +180,24 @@ class ModbusChargePeriodFactory:
             icon="mdi:timer-stop-outline",
             validate=[Time()],
         )
-        self.enable_force_charge = ModbusEnableForceChargeSensorDescription(
-            key=enable_force_charge_key,
-            name=enable_force_charge_name,
-            period_start_address=period_start_address,
-            period_end_address=period_end_address,
-            validate=[Time()],
-        )
+        if enable_force_charge_from_enable_address:
+            # Inverters which define charge periods via the time-group system (e.g. the H3 Smart) control
+            # force charge with a dedicated enable register (the time-group enable), rather than by
+            # inferring it from the start/end times.
+            self.enable_force_charge = ModbusBinarySensorDescription(
+                key=enable_force_charge_key,
+                name=enable_force_charge_name,
+                address=enable_address,
+                icon_func=lambda x: "mdi:battery-lock" if x else "mdi:battery-lock-open",
+            )
+        else:
+            self.enable_force_charge = ModbusEnableForceChargeSensorDescription(
+                key=enable_force_charge_key,
+                name=enable_force_charge_name,
+                period_start_address=period_start_address,
+                period_end_address=period_end_address,
+                validate=[Time()],
+            )
         self.enable_charge_from_grid = ModbusBinarySensorDescription(
             key=enable_charge_from_grid_key,
             name=enable_charge_from_grid_name,

--- a/custom_components/foxess_modbus/entities/modbus_charge_period_config.py
+++ b/custom_components/foxess_modbus/entities/modbus_charge_period_config.py
@@ -10,6 +10,7 @@ from homeassistant.const import Platform
 from ..common.entity_controller import EntityController
 from ..common.types import Inv
 from ..common.types import RegisterType
+from .entity_factory import EntityFactory
 from .inverter_model_spec import InverterModelSpec
 from .inverter_model_spec import ModbusAddressSpecBase
 from .modbus_binary_sensor import ModbusBinarySensorDescription
@@ -184,7 +185,7 @@ class ModbusChargePeriodFactory:
             # Inverters which define charge periods via the time-group system (e.g. the H3 Smart) control
             # force charge with a dedicated enable register (the time-group enable), rather than by
             # inferring it from the start/end times.
-            self.enable_force_charge = ModbusBinarySensorDescription(
+            self.enable_force_charge: EntityFactory = ModbusBinarySensorDescription(
                 key=enable_force_charge_key,
                 name=enable_force_charge_name,
                 address=enable_address,

--- a/custom_components/foxess_modbus/entities/modbus_entity_mixin.py
+++ b/custom_components/foxess_modbus/entities/modbus_entity_mixin.py
@@ -39,8 +39,10 @@ def get_entity_id(controller: EntityController, platform: Platform, key: str) ->
 
     if entity_id is None:
         # This can happen when first setting up, as the target entity hasn't been created yet.
-        # In this case, assume that it's going to be correctly named
-        entity_id = _add_entity_id_prefix(key, controller.inverter_details)
+        # In this case, assume that it's going to be correctly named. Make sure to include the
+        # platform domain, otherwise the entity ID won't match the state key that consumers
+        # (e.g. the charge period card) will use to look up the entity.
+        entity_id = f"{platform}.{_add_entity_id_prefix(key, controller.inverter_details)}"
 
     return entity_id
 

--- a/custom_components/foxess_modbus/services/update_charge_period_service.py
+++ b/custom_components/foxess_modbus/services/update_charge_period_service.py
@@ -320,11 +320,12 @@ def _make_time_group_writes(
     if not charge_period.enable_force_charge:
         return [(base, 0), (base + 6, 0)]
 
-    # The charge-period card doesn't expose a charge power or SoC target, so we use sensible defaults:
-    # charge up to 100% (from the grid if 'charge from grid' is enabled, otherwise PV only) at the inverter's
-    # full capacity.
-    max_soc = 100
-    min_soc = 10
+    # The charge-period card doesn't expose a charge power or SoC target, so we take the configured SoC
+    # bounds from the inverter's global Max SoC / Min SoC OnGrid registers (mirrored into the group's
+    # SoC bounds, matching how the FoxESS app does it), and charge from the grid at the inverter's full
+    # capacity if 'charge from grid' is enabled (otherwise PV only).
+    max_soc = _read_soc_value(controller, config.max_soc_global_address, 100)
+    min_soc = _read_soc_value(controller, config.min_soc_global_address, 10)
     fdpwr = controller.inverter_capacity if charge_period.enable_charge_from_grid else 0
 
     return [
@@ -333,12 +334,23 @@ def _make_time_group_writes(
         (base + 2, serialize_time_to_value(charge_period.end)),  # +2: End time (high byte=hour, low=min)
         (base + 3, 6),  # +3: Work mode = Force Charge
         (base + 4, (max_soc << 8) | min_soc),  # +4: MaxSoC (high byte) | MinSoC (low byte)
-        (base + 5, min_soc),  # +5: FDSOC
+        (base + 5, max_soc),  # +5: FCSOC/FDSOC (force charge SoC target = MaxSoC, like the app)
         (base + 6, fdpwr),  # +6: FDPWR (force charge power, W)
         (base + 7, 0),  # +7: reserve
         (base + 8, 0),  # +8: reserve
         (base + 9, 1),  # +9: enable flag (undocumented, but required for force charge)
     ]
+
+
+def _read_soc_value(controller: ModbusController, address: int | None, default: int) -> int:
+    """Reads a SoC (percentage) register, returning `default` if the register isn't configured or unreadable."""
+
+    if address is None:
+        return default
+    value = controller.read(address, signed=False)
+    if value is None or not 10 <= value <= 100:
+        return default
+    return value
 
 
 def _split_into_contiguous_runs(writes: list[tuple[int, int]]) -> list[tuple[int, list[int]]]:

--- a/custom_components/foxess_modbus/services/update_charge_period_service.py
+++ b/custom_components/foxess_modbus/services/update_charge_period_service.py
@@ -12,6 +12,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 
 from ..const import DOMAIN
+from ..entities.modbus_charge_period_config import ModbusChargePeriodAddressConfig
 from ..entities.modbus_charge_period_sensors import is_time_value_valid
 from ..entities.modbus_charge_period_sensors import parse_time_value
 from ..entities.modbus_charge_period_sensors import serialize_time_to_value
@@ -206,8 +207,20 @@ async def _update_charge_period(
                 f"{i + 1} is not valid"
             )
 
+        # Inverters which use the time-group charge period system (e.g. the H3 Smart) control force charge
+        # via a dedicated group-enable register, rather than inferring it from the start/end times.
+        if charge_period.addresses.enable_address is not None:
+            enable_value = controller.read(charge_period.addresses.enable_address, signed=False)
+            if enable_value is None:
+                raise HomeAssistantError(
+                    f"Data for charge period {i + 1} is not available. Please try again in a few seconds"
+                )
+            enable_force_charge = enable_value > 0
+        else:
+            enable_force_charge = period_start_time_value > 0 or period_end_time_value > 0
+
         charge_periods[i] = ChargePeriod(
-            enable_force_charge=period_start_time_value > 0 or period_end_time_value > 0,
+            enable_force_charge=enable_force_charge,
             enable_charge_from_grid=period_enable_charge_from_grid_value > 0,
             start=parse_time_value(period_start_time_value),
             end=parse_time_value(period_end_time_value),
@@ -231,42 +244,112 @@ async def _set_charge_periods(controller: ModbusController, charge_periods: list
     # (One charge period can contain another, or starts/ends can overlap).
     # Mirror this for consistancy, even though it is a little odd.
 
-    # List of (address, value)
-    writes: list[tuple[int, int]] = []
+    # Inverters which use the time-group charge period system (e.g. the H3 Smart) only run their time
+    # periods when the Time Period System is enabled (register 48000 = 1, the inverter's "Timer"/"Modus
+    # Terminierer" mode). Following the H1 semantics of an additive charge-period window, we tie this to
+    # whether any charge period is enabled: if any is enabled the time period system is switched on, and
+    # when all of them are disabled it is switched off again, so that the inverter returns to its normal
+    # (e.g. "Self Use") mode, just like the H1 does.
+    writes = []
+    is_time_group = False
     for charge_period, config in zip(charge_periods, controller.charge_periods, strict=True):
-        writes.append(
-            (
-                config.addresses.period_start_address,
-                serialize_time_to_value(charge_period.start) if charge_period.enable_force_charge else 0,
-            )
-        )
-        writes.append(
-            (
-                config.addresses.period_end_address,
-                serialize_time_to_value(charge_period.end) if charge_period.enable_force_charge else 0,
-            )
-        )
-        writes.append(
-            (
-                config.addresses.enable_charge_from_grid_address,
-                1 if charge_period.enable_charge_from_grid else 0,
-            )
-        )
+        if config.addresses.enable_address is not None:
+            is_time_group = True
+        writes.extend(_make_charge_period_writes(config.addresses, controller, charge_period))
 
-    # We expect all of the writes to have a contiguous set of addresses
-    write_values: list[int] = [None] * len(writes)  # type: ignore
-    write_start_address = min(write[0] for write in writes)
+    # Don't write the Time Period Mode flag (48000) from every enabled period: it's a single global register.
+    if is_time_group:
+        any_enabled = any(cp.enable_force_charge for cp in charge_periods)
+        writes.append((48000, 1 if any_enabled else 0))
 
-    for address, value in writes:
-        i = address - write_start_address
-        assert i < len(write_values)
-        assert write_values[i] is None
-        write_values[i] = value
+    write_blocks = _split_into_contiguous_runs(writes)
 
-    assert not any(x for x in write_values if x is None)
+    for write_start_address, write_values in write_blocks:
+        try:
+            await controller.write_registers(write_start_address, write_values)
+        except ModbusIOException as ex:
+            _LOGGER.warning(ex, exc_info=True)
+            raise HomeAssistantError() from ex
 
-    try:
-        await controller.write_registers(write_start_address, write_values)
-    except ModbusIOException as ex:
-        _LOGGER.warning(ex, exc_info=True)
-        raise HomeAssistantError() from ex
+
+def _make_charge_period_writes(
+    config: ModbusChargePeriodAddressConfig,
+    controller: ModbusController,
+    charge_period: ChargePeriod,
+) -> list[tuple[int, int]]:
+    """Builds the (address, value) register writes for a single charge period."""
+
+    if config.enable_address is not None:
+        return _make_time_group_writes(config, controller, charge_period)
+
+    return [
+        (
+            config.period_start_address,
+            serialize_time_to_value(charge_period.start) if charge_period.enable_force_charge else 0,
+        ),
+        (
+            config.period_end_address,
+            serialize_time_to_value(charge_period.end) if charge_period.enable_force_charge else 0,
+        ),
+        (
+            config.enable_charge_from_grid_address,
+            1 if charge_period.enable_charge_from_grid else 0,
+        ),
+    ]
+
+
+def _make_time_group_writes(
+    config: ModbusChargePeriodAddressConfig,
+    controller: ModbusController,
+    charge_period: ChargePeriod,
+) -> list[tuple[int, int]]:
+    """Builds the register writes for an inverter which uses the time-group charge period system (e.g. H3 Smart).
+
+    A time group is a contiguous block of 10 registers (see FoxESS Modbus protocol, Table 3-11). When a
+    charge period is enabled, the group is activated in Force Charge mode (Work Mode 6). "Charge from grid"
+    simply controls the force-charge power (FDPWR): enabled charges from the grid at the inverter's full
+    capacity, disabled charges from PV only (FDPWR = 0).
+
+    When a charge period is disabled, the group is turned off and the force-charge power is cleared, so that
+    the "charge from grid" state doesn't linger as on. The previously configured times are left intact.
+    """
+
+    base = config.enable_address
+    assert base is not None
+
+    if not charge_period.enable_force_charge:
+        return [(base, 0), (base + 6, 0)]
+
+    # The charge-period card doesn't expose a charge power or SoC target, so we use sensible defaults:
+    # charge up to 100% (from the grid if 'charge from grid' is enabled, otherwise PV only) at the inverter's
+    # full capacity.
+    max_soc = 100
+    min_soc = 10
+    fdpwr = controller.inverter_capacity if charge_period.enable_charge_from_grid else 0
+
+    return [
+        (base, 1),  # +0: Time group enable
+        (base + 1, serialize_time_to_value(charge_period.start)),  # +1: Start time (high byte=hour, low=min)
+        (base + 2, serialize_time_to_value(charge_period.end)),  # +2: End time (high byte=hour, low=min)
+        (base + 3, 6),  # +3: Work mode = Force Charge
+        (base + 4, (max_soc << 8) | min_soc),  # +4: MaxSoC (high byte) | MinSoC (low byte)
+        (base + 5, min_soc),  # +5: FDSOC
+        (base + 6, fdpwr),  # +6: FDPWR (force charge power, W)
+        (base + 7, 0),  # +7: reserve
+        (base + 8, 0),  # +8: reserve
+        (base + 9, 1),  # +9: enable flag (undocumented, but required for force charge)
+    ]
+
+
+def _split_into_contiguous_runs(writes: list[tuple[int, int]]) -> list[tuple[int, list[int]]]:
+    """Groups a list of (address, value) writes into contiguous register runs, each returned as (start, values)."""
+
+    runs: list[tuple[int, list[int]]] = []
+    for address, value in sorted(writes, key=lambda x: x[0]):
+        if runs and address == runs[-1][0] + len(runs[-1][1]):
+            start, values = runs[-1]
+            runs[-1] = (start, [*values, value])
+        else:
+            runs.append((address, [value]))
+
+    return runs

--- a/tests/__snapshots__/test_entity_descriptions/test_entities[1KOMMA5-AUX-latest].json
+++ b/tests/__snapshots__/test_entity_descriptions/test_entities[1KOMMA5-AUX-latest].json
@@ -1422,6 +1422,74 @@
   },
   {
     "addresses": [
+      48016
+    ],
+    "key": "time_period_1_enable_charge_from_grid",
+    "name": "Period 1 - Enable Charge from Grid",
+    "type": "binary-sensor"
+  },
+  {
+    "addresses": [
+      48010
+    ],
+    "key": "time_period_1_enable_force_charge",
+    "name": "Period 1 - Enable Force Charge",
+    "type": "binary-sensor"
+  },
+  {
+    "addresses": [
+      48012
+    ],
+    "key": "time_period_1_end",
+    "name": "Period 1 - End",
+    "other_addresses": 48011,
+    "type": "charge-period-time"
+  },
+  {
+    "addresses": [
+      48011
+    ],
+    "key": "time_period_1_start",
+    "name": "Period 1 - Start",
+    "other_addresses": 48012,
+    "type": "charge-period-time"
+  },
+  {
+    "addresses": [
+      48026
+    ],
+    "key": "time_period_2_enable_charge_from_grid",
+    "name": "Period 2 - Enable Charge from Grid",
+    "type": "binary-sensor"
+  },
+  {
+    "addresses": [
+      48020
+    ],
+    "key": "time_period_2_enable_force_charge",
+    "name": "Period 2 - Enable Force Charge",
+    "type": "binary-sensor"
+  },
+  {
+    "addresses": [
+      48022
+    ],
+    "key": "time_period_2_end",
+    "name": "Period 2 - End",
+    "other_addresses": 48021,
+    "type": "charge-period-time"
+  },
+  {
+    "addresses": [
+      48021
+    ],
+    "key": "time_period_2_start",
+    "name": "Period 2 - Start",
+    "other_addresses": 48022,
+    "type": "charge-period-time"
+  },
+  {
+    "addresses": [
       39624,
       39623
     ],

--- a/tests/__snapshots__/test_entity_descriptions/test_entities[ENPAL_IX-AUX-latest].json
+++ b/tests/__snapshots__/test_entity_descriptions/test_entities[ENPAL_IX-AUX-latest].json
@@ -1422,6 +1422,74 @@
   },
   {
     "addresses": [
+      48016
+    ],
+    "key": "time_period_1_enable_charge_from_grid",
+    "name": "Period 1 - Enable Charge from Grid",
+    "type": "binary-sensor"
+  },
+  {
+    "addresses": [
+      48010
+    ],
+    "key": "time_period_1_enable_force_charge",
+    "name": "Period 1 - Enable Force Charge",
+    "type": "binary-sensor"
+  },
+  {
+    "addresses": [
+      48012
+    ],
+    "key": "time_period_1_end",
+    "name": "Period 1 - End",
+    "other_addresses": 48011,
+    "type": "charge-period-time"
+  },
+  {
+    "addresses": [
+      48011
+    ],
+    "key": "time_period_1_start",
+    "name": "Period 1 - Start",
+    "other_addresses": 48012,
+    "type": "charge-period-time"
+  },
+  {
+    "addresses": [
+      48026
+    ],
+    "key": "time_period_2_enable_charge_from_grid",
+    "name": "Period 2 - Enable Charge from Grid",
+    "type": "binary-sensor"
+  },
+  {
+    "addresses": [
+      48020
+    ],
+    "key": "time_period_2_enable_force_charge",
+    "name": "Period 2 - Enable Force Charge",
+    "type": "binary-sensor"
+  },
+  {
+    "addresses": [
+      48022
+    ],
+    "key": "time_period_2_end",
+    "name": "Period 2 - End",
+    "other_addresses": 48021,
+    "type": "charge-period-time"
+  },
+  {
+    "addresses": [
+      48021
+    ],
+    "key": "time_period_2_start",
+    "name": "Period 2 - Start",
+    "other_addresses": 48022,
+    "type": "charge-period-time"
+  },
+  {
+    "addresses": [
       39624,
       39623
     ],

--- a/tests/__snapshots__/test_entity_descriptions/test_entities[H3_PRO-AUX-latest].json
+++ b/tests/__snapshots__/test_entity_descriptions/test_entities[H3_PRO-AUX-latest].json
@@ -1572,6 +1572,74 @@
   },
   {
     "addresses": [
+      48016
+    ],
+    "key": "time_period_1_enable_charge_from_grid",
+    "name": "Period 1 - Enable Charge from Grid",
+    "type": "binary-sensor"
+  },
+  {
+    "addresses": [
+      48010
+    ],
+    "key": "time_period_1_enable_force_charge",
+    "name": "Period 1 - Enable Force Charge",
+    "type": "binary-sensor"
+  },
+  {
+    "addresses": [
+      48012
+    ],
+    "key": "time_period_1_end",
+    "name": "Period 1 - End",
+    "other_addresses": 48011,
+    "type": "charge-period-time"
+  },
+  {
+    "addresses": [
+      48011
+    ],
+    "key": "time_period_1_start",
+    "name": "Period 1 - Start",
+    "other_addresses": 48012,
+    "type": "charge-period-time"
+  },
+  {
+    "addresses": [
+      48026
+    ],
+    "key": "time_period_2_enable_charge_from_grid",
+    "name": "Period 2 - Enable Charge from Grid",
+    "type": "binary-sensor"
+  },
+  {
+    "addresses": [
+      48020
+    ],
+    "key": "time_period_2_enable_force_charge",
+    "name": "Period 2 - Enable Force Charge",
+    "type": "binary-sensor"
+  },
+  {
+    "addresses": [
+      48022
+    ],
+    "key": "time_period_2_end",
+    "name": "Period 2 - End",
+    "other_addresses": 48021,
+    "type": "charge-period-time"
+  },
+  {
+    "addresses": [
+      48021
+    ],
+    "key": "time_period_2_start",
+    "name": "Period 2 - Start",
+    "other_addresses": 48022,
+    "type": "charge-period-time"
+  },
+  {
+    "addresses": [
       39624,
       39623
     ],

--- a/tests/__snapshots__/test_entity_descriptions/test_entities[H3_PRO-AUX-v1.22].json
+++ b/tests/__snapshots__/test_entity_descriptions/test_entities[H3_PRO-AUX-v1.22].json
@@ -1441,6 +1441,74 @@
   },
   {
     "addresses": [
+      48016
+    ],
+    "key": "time_period_1_enable_charge_from_grid",
+    "name": "Period 1 - Enable Charge from Grid",
+    "type": "binary-sensor"
+  },
+  {
+    "addresses": [
+      48010
+    ],
+    "key": "time_period_1_enable_force_charge",
+    "name": "Period 1 - Enable Force Charge",
+    "type": "binary-sensor"
+  },
+  {
+    "addresses": [
+      48012
+    ],
+    "key": "time_period_1_end",
+    "name": "Period 1 - End",
+    "other_addresses": 48011,
+    "type": "charge-period-time"
+  },
+  {
+    "addresses": [
+      48011
+    ],
+    "key": "time_period_1_start",
+    "name": "Period 1 - Start",
+    "other_addresses": 48012,
+    "type": "charge-period-time"
+  },
+  {
+    "addresses": [
+      48026
+    ],
+    "key": "time_period_2_enable_charge_from_grid",
+    "name": "Period 2 - Enable Charge from Grid",
+    "type": "binary-sensor"
+  },
+  {
+    "addresses": [
+      48020
+    ],
+    "key": "time_period_2_enable_force_charge",
+    "name": "Period 2 - Enable Force Charge",
+    "type": "binary-sensor"
+  },
+  {
+    "addresses": [
+      48022
+    ],
+    "key": "time_period_2_end",
+    "name": "Period 2 - End",
+    "other_addresses": 48021,
+    "type": "charge-period-time"
+  },
+  {
+    "addresses": [
+      48021
+    ],
+    "key": "time_period_2_start",
+    "name": "Period 2 - Start",
+    "other_addresses": 48022,
+    "type": "charge-period-time"
+  },
+  {
+    "addresses": [
       39624,
       39623
     ],

--- a/tests/__snapshots__/test_entity_descriptions/test_entities[H3_SMART-AUX-latest].json
+++ b/tests/__snapshots__/test_entity_descriptions/test_entities[H3_SMART-AUX-latest].json
@@ -1422,6 +1422,74 @@
   },
   {
     "addresses": [
+      48016
+    ],
+    "key": "time_period_1_enable_charge_from_grid",
+    "name": "Period 1 - Enable Charge from Grid",
+    "type": "binary-sensor"
+  },
+  {
+    "addresses": [
+      48010
+    ],
+    "key": "time_period_1_enable_force_charge",
+    "name": "Period 1 - Enable Force Charge",
+    "type": "binary-sensor"
+  },
+  {
+    "addresses": [
+      48012
+    ],
+    "key": "time_period_1_end",
+    "name": "Period 1 - End",
+    "other_addresses": 48011,
+    "type": "charge-period-time"
+  },
+  {
+    "addresses": [
+      48011
+    ],
+    "key": "time_period_1_start",
+    "name": "Period 1 - Start",
+    "other_addresses": 48012,
+    "type": "charge-period-time"
+  },
+  {
+    "addresses": [
+      48026
+    ],
+    "key": "time_period_2_enable_charge_from_grid",
+    "name": "Period 2 - Enable Charge from Grid",
+    "type": "binary-sensor"
+  },
+  {
+    "addresses": [
+      48020
+    ],
+    "key": "time_period_2_enable_force_charge",
+    "name": "Period 2 - Enable Force Charge",
+    "type": "binary-sensor"
+  },
+  {
+    "addresses": [
+      48022
+    ],
+    "key": "time_period_2_end",
+    "name": "Period 2 - End",
+    "other_addresses": 48021,
+    "type": "charge-period-time"
+  },
+  {
+    "addresses": [
+      48021
+    ],
+    "key": "time_period_2_start",
+    "name": "Period 2 - Start",
+    "other_addresses": 48022,
+    "type": "charge-period-time"
+  },
+  {
+    "addresses": [
       39624,
       39623
     ],

--- a/tests/__snapshots__/test_entity_descriptions/test_entities[P3_SMART-AUX-latest].json
+++ b/tests/__snapshots__/test_entity_descriptions/test_entities[P3_SMART-AUX-latest].json
@@ -1422,6 +1422,74 @@
   },
   {
     "addresses": [
+      48016
+    ],
+    "key": "time_period_1_enable_charge_from_grid",
+    "name": "Period 1 - Enable Charge from Grid",
+    "type": "binary-sensor"
+  },
+  {
+    "addresses": [
+      48010
+    ],
+    "key": "time_period_1_enable_force_charge",
+    "name": "Period 1 - Enable Force Charge",
+    "type": "binary-sensor"
+  },
+  {
+    "addresses": [
+      48012
+    ],
+    "key": "time_period_1_end",
+    "name": "Period 1 - End",
+    "other_addresses": 48011,
+    "type": "charge-period-time"
+  },
+  {
+    "addresses": [
+      48011
+    ],
+    "key": "time_period_1_start",
+    "name": "Period 1 - Start",
+    "other_addresses": 48012,
+    "type": "charge-period-time"
+  },
+  {
+    "addresses": [
+      48026
+    ],
+    "key": "time_period_2_enable_charge_from_grid",
+    "name": "Period 2 - Enable Charge from Grid",
+    "type": "binary-sensor"
+  },
+  {
+    "addresses": [
+      48020
+    ],
+    "key": "time_period_2_enable_force_charge",
+    "name": "Period 2 - Enable Force Charge",
+    "type": "binary-sensor"
+  },
+  {
+    "addresses": [
+      48022
+    ],
+    "key": "time_period_2_end",
+    "name": "Period 2 - End",
+    "other_addresses": 48021,
+    "type": "charge-period-time"
+  },
+  {
+    "addresses": [
+      48021
+    ],
+    "key": "time_period_2_start",
+    "name": "Period 2 - Start",
+    "other_addresses": 48022,
+    "type": "charge-period-time"
+  },
+  {
+    "addresses": [
       39624,
       39623
     ],

--- a/tests/__snapshots__/test_entity_descriptions/test_entities[SK-HWR-SMART-AUX-latest].json
+++ b/tests/__snapshots__/test_entity_descriptions/test_entities[SK-HWR-SMART-AUX-latest].json
@@ -1422,6 +1422,74 @@
   },
   {
     "addresses": [
+      48016
+    ],
+    "key": "time_period_1_enable_charge_from_grid",
+    "name": "Period 1 - Enable Charge from Grid",
+    "type": "binary-sensor"
+  },
+  {
+    "addresses": [
+      48010
+    ],
+    "key": "time_period_1_enable_force_charge",
+    "name": "Period 1 - Enable Force Charge",
+    "type": "binary-sensor"
+  },
+  {
+    "addresses": [
+      48012
+    ],
+    "key": "time_period_1_end",
+    "name": "Period 1 - End",
+    "other_addresses": 48011,
+    "type": "charge-period-time"
+  },
+  {
+    "addresses": [
+      48011
+    ],
+    "key": "time_period_1_start",
+    "name": "Period 1 - Start",
+    "other_addresses": 48012,
+    "type": "charge-period-time"
+  },
+  {
+    "addresses": [
+      48026
+    ],
+    "key": "time_period_2_enable_charge_from_grid",
+    "name": "Period 2 - Enable Charge from Grid",
+    "type": "binary-sensor"
+  },
+  {
+    "addresses": [
+      48020
+    ],
+    "key": "time_period_2_enable_force_charge",
+    "name": "Period 2 - Enable Force Charge",
+    "type": "binary-sensor"
+  },
+  {
+    "addresses": [
+      48022
+    ],
+    "key": "time_period_2_end",
+    "name": "Period 2 - End",
+    "other_addresses": 48021,
+    "type": "charge-period-time"
+  },
+  {
+    "addresses": [
+      48021
+    ],
+    "key": "time_period_2_start",
+    "name": "Period 2 - Start",
+    "other_addresses": 48022,
+    "type": "charge-period-time"
+  },
+  {
+    "addresses": [
       39624,
       39623
     ],


### PR DESCRIPTION
## Summary

The charge period card works on H1/G2/EVO via the `41001..41006` charge period registers. The **H3 Smart** (and H3 Pro, which shares the same register map) has those registers marked invalid and instead defines charge periods with the **time-group system** (Table 3-11, base `48010 + 10*(N-1)`). This PR adds time-group charge period support for `Inv.H3_PRO_SET | Inv.H3_SMART`.

## Changes

- **`entities/modbus_charge_period_config.py`**
  - `ModbusChargePeriodAddressConfig`: added optional time-group fields (`enable_address`, `work_mode_address`, `soc_address`, `fdsoc_address`, `fdpwr_address`, `enable_flag_address`). `enable_address` doubles as the base of the 10-register block.
  - `ChargePeriodAddressSpec`: getters for the new fields; `_get_address` tolerates `None` (H1 configs unaffected).
  - `ModbusChargePeriodFactory`: new option to derive the force-charge binary sensor from the group enable register instead of the start/end times.
- **`entities/charge_period_descriptions.py`**: factories for H3 groups 1 and 2 (the same groups the FoxESS app uses) with Work Mode 6 (Force Charge) and FDPWR (`base+6`) as the "charge from grid" register (also the marker entity the card uses to discover supported inverters).
- **`entities/modbus_entity_mixin.py`**: `get_entity_id` fallback now includes the platform domain, so the charge period card can resolve entities before they are registered.
- **`services/update_charge_period_service.py`**: for time-group inverters, write the full group block (enable, start/end, Work Mode 6, SoC, FDPWR, enable flag) and tie the Time Period Mode flag (`48000`) to whether any period is enabled. The H1 write path is preserved (writes are split into contiguous runs).

## Testing

- Verified live on an H3 Smart (`Foxy`): Period off → normal/discharge; Period on + grid off → PV-only force charge; Period on + grid on → grid charging.
- `python -m pytest`: 35 passed (snapshots regenerated for the models mapping to `Inv.H3_SMART` / `Inv.H3_PRO_SET`).
- `ruff`, `ruff format --check`, `mypy`: clean.

## Notes / limitations

- The device/app must be in "Modus Terminierer" (the time-period mode) for the groups to run; this is the app/Cloud level and not set by the card.
- Force-charge power defaults to the inverter capacity (grid on) and SoC bounds default to 100/10, as the card doesn't expose these.